### PR TITLE
Added a `__len__` and `__getitem__` for anndata_rs.

### DIFF
--- a/pyanndata/src/anndata/backed.rs
+++ b/pyanndata/src/anndata/backed.rs
@@ -560,6 +560,10 @@ impl AnnData {
     fn __str__(&self) -> String {
         self.__repr__()
     }
+
+    fn __len__(&self) -> usize {
+        self.n_obs()
+    }
 }
 
 trait AnnDataTrait: Send + Sync + Downcast {

--- a/pyanndata/src/anndata/backed.rs
+++ b/pyanndata/src/anndata/backed.rs
@@ -564,6 +564,14 @@ impl AnnData {
     fn __len__(&self) -> usize {
         self.n_obs()
     }
+    
+    fn __getitem__<'py>(&self, py: Python<'py>, key: &Bound<'py, PyAny>) -> Result<Option<Bound<'py, PyAny>>> { 
+        let i = Some(key)
+            .map(|x| self.select_obs(x).unwrap())
+            .unwrap_or(SelectInfoElem::full());
+        
+        self.0.subset(py, &[i, SelectInfoElem::full()], None, false, Some(self.0.backend()))
+    }
 }
 
 trait AnnDataTrait: Send + Sync + Downcast {


### PR DESCRIPTION
I found it useful to make `anndata_rs` subscribable, and having a `__len__` method is helpful when lazily creating PyTorch DataLoaders.

My PR is pretty small, just added two functions:
```{rust}
fn __len__(&self) -> usize {
        self.n_obs()
    }
    
fn __getitem__<'py>(&self, py: Python<'py>, key: &Bound<'py, PyAny>) -> Result<Option<Bound<'py, PyAny>>> { 
    let i = Some(key)
        .map(|x| self.select_obs(x).unwrap())
        .unwrap_or(SelectInfoElem::full());
    
    self.0.subset(py, &[i, SelectInfoElem::full()], None, false, Some(self.0.backend()))
}
 ```

I'm not sure if my `__getitem__` implementation is the most efficient, so feel free to improve it.

Thanks again for your work on this repo!