### PR TITLE
style: format and clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Continuous integration
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   test_rust_code:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
     - name: Test Rust package
       run: cargo test --no-fail-fast
 
-    - name: Format Rust code
-      run: cargo fmt --check
-
     - name: Check Rust code
       run: cargo clippy --all-targets --all-features -- -D warnings
+
+    - name: Format Rust code
+      run: cargo fmt --check
 
     #- name: benchmark
     #  run: |
@@ -112,3 +112,15 @@ jobs:
         publish_dir: ./documentation
         publish_branch: gh-pages
         force_orphan: true
+
+  check:
+    if: always()
+    needs:
+    - test_rust_code
+    - upload_gh-page  # depends on the rest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ jobs:
     - name: Test Rust package
       run: cargo test --no-fail-fast
 
+    - name: Format Rust code
+      run: cargo fmt --check
+
+    - name: Check Rust code
+      run: cargo clippy --all-targets --all-features -- -D warnings
+
     #- name: benchmark
     #  run: |
     #    cd ${GITHUB_WORKSPACE}/anndata-test-utils && cargo bench
@@ -36,7 +42,7 @@ jobs:
       matrix:
         anndata_version: ['0.9.*', '0.10.*', '0.11.*', '0.12.*']
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - uses: actions-rs/toolchain@v1
       with:
@@ -58,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test_python_code]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - uses: actions-rs/toolchain@v1
       with:
@@ -85,7 +91,7 @@ jobs:
         sphinx-build ${GITHUB_WORKSPACE}/python/docs _build/html
 
     - name: Upload doc
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: documentation
         path: ./_build/html
@@ -96,7 +102,7 @@ jobs:
     needs: [build_doc]
     steps:
     - name: Download
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
 
     - name: Upload doc
       uses: peaceiris/actions-gh-pages@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ anndata-zarr = { path = "anndata-zarr" }
 pyanndata = { path = "pyanndata" }
 
 [workspace.lints.clippy]
+# TODO: replace these with `pedantic`
+uninlined_format_args = "warn"
 #pedantic = { priority = -1, level = "warn" }
 # TODO: remove these “allow”s
 similar_names = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,8 @@ anndata = { path = "anndata" }
 anndata-hdf5 = { path = "anndata-hdf5" }
 anndata-zarr = { path = "anndata-zarr" }
 pyanndata = { path = "pyanndata" }
+
+[workspace.lints.clippy]
+#pedantic = { priority = -1, level = "warn" }
+# TODO: remove these “allow”s
+similar_names = "allow"

--- a/anndata-hdf5/Cargo.toml
+++ b/anndata-hdf5/Cargo.toml
@@ -24,3 +24,6 @@ ndarray = "0.17"
 tempfile = "3.2"
 rand = "0.8.5"
 ndarray-rand = "0.16"
+
+[lints]
+workspace = true

--- a/anndata-hdf5/src/lib.rs
+++ b/anndata-hdf5/src/lib.rs
@@ -247,7 +247,7 @@ impl DatasetOp<H5> for H5Dataset {
             TypeDescriptor::Boolean => ScalarType::Bool,
             TypeDescriptor::VarLenAscii => ScalarType::String,
             TypeDescriptor::VarLenUnicode => ScalarType::String,
-            ty => bail!("Unsupported type: {:?}", ty),
+            ty => bail!("Unsupported type: {ty:?}"),
         };
         Ok(ty)
     }
@@ -641,7 +641,7 @@ fn read_scalar_attr(loc: &Location, name: &str) -> Result<Value> {
         TypeDescriptor::Unsigned(_) => attr.read_scalar::<u64>()?.into(),
         TypeDescriptor::Integer(_) => attr.read_scalar::<i64>()?.into(),
         TypeDescriptor::Float(_) => attr.read_scalar::<f64>()?.into(),
-        v => bail!("Unsupported type {}", v),
+        v => bail!("Unsupported type {v}"),
     };
     Ok(result)
 }
@@ -659,7 +659,7 @@ fn read_array_attr(loc: &Location, name: &str) -> Result<Value> {
         TypeDescriptor::Unsigned(_) => ndarray_to_json(&attr.read::<u64, IxDyn>()?),
         TypeDescriptor::Integer(_) => ndarray_to_json(&attr.read::<i64, IxDyn>()?),
         TypeDescriptor::Float(_) => ndarray_to_json(&attr.read::<f64, IxDyn>()?),
-        v => bail!("Unsupported type {}", v),
+        v => bail!("Unsupported type {v}"),
     };
     Ok(result)
 }

--- a/anndata-hdf5/src/lib.rs
+++ b/anndata-hdf5/src/lib.rs
@@ -18,9 +18,9 @@ use ndarray::{Array, ArrayD, ArrayView, CowArray, Dimension, IxDyn, SliceInfo, S
 use std::ops::{Deref, Index};
 use std::path::{Path, PathBuf};
 
-///////////////////////////////////////////////////////////////////////////////
-/// Type definitions
-///////////////////////////////////////////////////////////////////////////////
+//-----------------------------------------------------------------------------
+// Type definitions
+//-----------------------------------------------------------------------------
 
 pub struct H5;
 
@@ -54,9 +54,9 @@ impl Deref for H5Dataset {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-/// Backend implementation
-///////////////////////////////////////////////////////////////////////////////
+//-----------------------------------------------------------------------------
+// Backend implementation
+//-----------------------------------------------------------------------------
 
 impl Backend for H5 {
     const NAME: &'static str = "hdf5";
@@ -82,7 +82,7 @@ impl Backend for H5 {
 
 impl StoreOp<H5> for H5File {
     fn filename(&self) -> PathBuf {
-        hdf5::Location::filename(&self).into()
+        hdf5::Location::filename(self).into()
     }
 
     fn close(self) -> Result<()> {
@@ -166,7 +166,7 @@ fn exists(group: &Group, name: &str) -> Result<bool> {
 }
 
 fn create_scalar_data<D: BackendData>(group: &Group, name: &str, data: &D) -> Result<H5Dataset> {
-    match data.into_dyn() {
+    match data.as_dyn() {
         DynScalar::U8(x) => {
             let dataset = group.new_dataset::<u8>().create(name)?;
             dataset.write_scalar(&x)?;
@@ -262,20 +262,20 @@ impl DatasetOp<H5> for H5Dataset {
 
     fn read_scalar<T: BackendData>(&self) -> Result<T> {
         let val = match T::DTYPE {
-            ScalarType::Bool => self.deref().read_scalar::<bool>()?.into_dyn(),
-            ScalarType::U8 => self.deref().read_scalar::<u8>()?.into_dyn(),
-            ScalarType::U16 => self.deref().read_scalar::<u16>()?.into_dyn(),
-            ScalarType::U32 => self.deref().read_scalar::<u32>()?.into_dyn(),
-            ScalarType::U64 => self.deref().read_scalar::<u64>()?.into_dyn(),
-            ScalarType::I8 => self.deref().read_scalar::<i8>()?.into_dyn(),
-            ScalarType::I16 => self.deref().read_scalar::<i16>()?.into_dyn(),
-            ScalarType::I32 => self.deref().read_scalar::<i32>()?.into_dyn(),
-            ScalarType::I64 => self.deref().read_scalar::<i64>()?.into_dyn(),
-            ScalarType::F32 => self.deref().read_scalar::<f32>()?.into_dyn(),
-            ScalarType::F64 => self.deref().read_scalar::<f64>()?.into_dyn(),
+            ScalarType::Bool => self.deref().read_scalar::<bool>()?.as_dyn(),
+            ScalarType::U8 => self.deref().read_scalar::<u8>()?.as_dyn(),
+            ScalarType::U16 => self.deref().read_scalar::<u16>()?.as_dyn(),
+            ScalarType::U32 => self.deref().read_scalar::<u32>()?.as_dyn(),
+            ScalarType::U64 => self.deref().read_scalar::<u64>()?.as_dyn(),
+            ScalarType::I8 => self.deref().read_scalar::<i8>()?.as_dyn(),
+            ScalarType::I16 => self.deref().read_scalar::<i16>()?.as_dyn(),
+            ScalarType::I32 => self.deref().read_scalar::<i32>()?.as_dyn(),
+            ScalarType::I64 => self.deref().read_scalar::<i64>()?.as_dyn(),
+            ScalarType::F32 => self.deref().read_scalar::<f32>()?.as_dyn(),
+            ScalarType::F64 => self.deref().read_scalar::<f64>()?.as_dyn(),
             ScalarType::String => {
                 let s = self.deref().read_scalar::<VarLenUnicode>()?;
-                s.to_string().into_dyn()
+                s.to_string().as_dyn()
             }
         };
         BackendData::from_dyn(val)
@@ -296,9 +296,9 @@ impl DatasetOp<H5> for H5Dataset {
             let arr = arr_.view().into_dyn();
             let slices = info
                 .as_ref()
-                .into_iter()
+                .iter()
                 .map(|x| match x.as_ref() {
-                    SelectInfoElem::Slice(slice) => Some(SliceInfoElem::from(slice.clone())),
+                    SelectInfoElem::Slice(slice) => Some(SliceInfoElem::from(*slice)),
                     _ => None,
                 })
                 .collect::<Option<Vec<_>>>();
@@ -308,7 +308,7 @@ impl DatasetOp<H5> for H5Dataset {
                 let shape = arr_.shape();
                 let select: Vec<_> = info
                     .as_ref()
-                    .into_iter()
+                    .iter()
                     .zip_longest(shape)
                     .map(|ty| match ty {
                         EitherOrBoth::Both(x, n) => SelectInfoElemBounds::new(x.as_ref(), *n),
@@ -321,10 +321,8 @@ impl DatasetOp<H5> for H5Dataset {
                     .collect();
                 let new_shape = select.iter().map(|x| x.len()).collect::<Vec<_>>();
                 ArrayD::from_shape_fn(new_shape, |idx| {
-                    let new_idx: Vec<_> = (0..idx.ndim())
-                        .into_iter()
-                        .map(|i| select[i].index(idx[i]))
-                        .collect();
+                    let new_idx: Vec<_> =
+                        (0..idx.ndim()).map(|i| select[i].index(idx[i])).collect();
                     arr.index(new_idx.as_slice()).clone()
                 })
             }
@@ -449,9 +447,9 @@ fn path(loc: &Location) -> PathBuf {
     hdf5::Location::name(loc).into()
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// Derived implementations
-////////////////////////////////////////////////////////////////////////////////
+//-----------------------------------------------------------------------------
+// Derived implementations
+//-----------------------------------------------------------------------------
 
 impl GroupOp<H5> for H5File {
     fn list(&self) -> Result<Vec<String>> {
@@ -697,7 +695,7 @@ where
 
 fn write_scalar_attr<D: BackendData>(loc: &Location, name: &str, value: D) -> Result<()> {
     del_attr(loc, name);
-    match value.into_dyn() {
+    match value.as_dyn() {
         DynScalar::U8(x) => loc.new_attr::<u8>().create(name)?.write_scalar(&x)?,
         DynScalar::U16(x) => loc.new_attr::<u16>().create(name)?.write_scalar(&x)?,
         DynScalar::U32(x) => loc.new_attr::<u32>().create(name)?.write_scalar(&x)?,
@@ -724,7 +722,7 @@ where
     S: AsRef<[E]>,
     E: AsRef<SelectInfoElem>,
 {
-    if selection.as_ref().into_iter().all(|x| x.as_ref().is_full()) {
+    if selection.as_ref().iter().all(|x| x.as_ref().is_full()) {
         (Selection::All, shape)
     } else {
         let bounded_selection = SelectInfoBounds::new(&selection, &shape);

--- a/anndata-test-utils/Cargo.toml
+++ b/anndata-test-utils/Cargo.toml
@@ -25,3 +25,6 @@ bincode = { version = "2", features = ["serde"] }
 zstd = "0.13"
 lz4_flex = "0.11"
 rayon = "1.10"
+
+[lints]
+workspace = true

--- a/anndata-test-utils/src/common/mod.rs
+++ b/anndata-test-utils/src/common/mod.rs
@@ -25,9 +25,9 @@ pub fn with_tmp_dir<T, F: FnMut(PathBuf) -> T>(mut func: F) -> T {
     func(path)
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// Strategies
-////////////////////////////////////////////////////////////////////////////////
+//-----------------------------------------------------------------------------
+// Strategies
+//-----------------------------------------------------------------------------
 
 /// Strategy for generating a random AnnData
 pub fn anndata_strat<B: Backend, P: AsRef<Path> + Clone>(
@@ -35,33 +35,33 @@ pub fn anndata_strat<B: Backend, P: AsRef<Path> + Clone>(
     n_obs: usize,
     n_vars: usize,
 ) -> impl Strategy<Value = AnnData<B>> {
-    let x = array_strat(&vec![n_obs, n_vars]);
+    let x = array_strat(&[n_obs, n_vars]);
     let obs_names = index_strat(n_obs);
-    let obsm = proptest::collection::vec(0 as usize..100, 0..3).prop_flat_map(move |shapes| {
+    let obsm = proptest::collection::vec(0_usize..100, 0..3).prop_flat_map(move |shapes| {
         shapes
             .into_iter()
-            .map(|d| array_strat(&vec![n_obs, d]))
+            .map(|d| array_strat(&[n_obs, d]))
             .collect::<Vec<_>>()
     });
-    let obsp = (0 as usize..3).prop_flat_map(move |d| {
-        std::iter::repeat_with(|| array_strat(&vec![n_obs, n_obs]))
+    let obsp = (0_usize..3).prop_flat_map(move |d| {
+        std::iter::repeat_with(|| array_strat(&[n_obs, n_obs]))
             .take(d)
             .collect::<Vec<_>>()
     });
     let var_names = index_strat(n_vars);
-    let varm = proptest::collection::vec(0 as usize..100, 0..3).prop_flat_map(move |shapes| {
+    let varm = proptest::collection::vec(0_usize..100, 0..3).prop_flat_map(move |shapes| {
         shapes
             .into_iter()
-            .map(|d| array_strat(&vec![n_vars, d]))
+            .map(|d| array_strat(&[n_vars, d]))
             .collect::<Vec<_>>()
     });
-    let varp = (0 as usize..3).prop_flat_map(move |d| {
-        std::iter::repeat_with(|| array_strat(&vec![n_vars, n_vars]))
+    let varp = (0_usize..3).prop_flat_map(move |d| {
+        std::iter::repeat_with(|| array_strat(&[n_vars, n_vars]))
             .take(d)
             .collect::<Vec<_>>()
     });
-    let layers = (0 as usize..3).prop_flat_map(move |d| {
-        std::iter::repeat_with(|| array_strat(&vec![n_obs, n_vars]))
+    let layers = (0_usize..3).prop_flat_map(move |d| {
+        std::iter::repeat_with(|| array_strat(&[n_obs, n_vars]))
             .take(d)
             .collect::<Vec<_>>()
     });
@@ -103,7 +103,7 @@ pub fn index_strat(n: usize) -> BoxedStrategy<DataFrameIndex> {
                 [a, b, c]
                     .into_iter()
                     .filter(|x| *x != 0)
-                    .map(|x| interval_strat(x))
+                    .map(interval_strat)
                     .collect::<Vec<_>>()
                     .prop_map(move |x| {
                         x.into_iter()
@@ -118,7 +118,7 @@ pub fn index_strat(n: usize) -> BoxedStrategy<DataFrameIndex> {
 }
 
 fn interval_strat(n: usize) -> impl Strategy<Value = Interval> {
-    (1 as usize..100, 1 as usize..100).prop_map(move |(size, step)| Interval {
+    (1_usize..100, 1_usize..100).prop_map(move |(size, step)| Interval {
         start: 0,
         end: n * step,
         size,
@@ -127,9 +127,9 @@ fn interval_strat(n: usize) -> impl Strategy<Value = Interval> {
 }
 
 pub fn array_slice_strat(
-    shape: &Vec<usize>,
+    shape: &[usize],
 ) -> impl Strategy<Value = (ArrayData, Vec<SelectInfoElem>)> {
-    array_strat(&shape).prop_flat_map(|x| {
+    array_strat(shape).prop_flat_map(|x| {
         let select = x
             .shape()
             .as_ref()
@@ -140,7 +140,7 @@ pub fn array_slice_strat(
     })
 }
 
-pub fn array_strat(shape: &Vec<usize>) -> impl Strategy<Value = ArrayData> {
+pub fn array_strat(shape: &[usize]) -> impl Strategy<Value = ArrayData> {
     prop_oneof![
         csr_strat(shape[0], shape[1]),
         csc_strat(shape[0], shape[1]),
@@ -184,87 +184,88 @@ pub fn csc_strat(num_rows: usize, num_cols: usize) -> impl Strategy<Value = Arra
     ]
 }
 
-fn dense_array_strat(shape: &Vec<usize>) -> impl Strategy<Value = ArrayData> {
-    let s: Vec<_> = shape.clone().into_iter().rev().collect();
+fn dense_array_strat(shape: &[usize]) -> impl Strategy<Value = ArrayData> {
+    let s: Vec<_> = shape.iter().copied().rev().collect();
+    let s = &s[..];
     prop_oneof![
-        Just(Array::random(shape.clone(), Uniform::new(0u8, 255u8).unwrap()).into()),
-        Just(Array::random(shape.clone(), Uniform::new(0u16, 255u16).unwrap()).into()),
-        Just(Array::random(shape.clone(), Uniform::new(0u32, 255u32).unwrap()).into()),
-        Just(Array::random(shape.clone(), Uniform::new(0u64, 255u64).unwrap()).into()),
-        Just(Array::random(shape.clone(), Uniform::new(-128i8, 127i8).unwrap()).into()),
-        Just(Array::random(shape.clone(), Uniform::new(-128i16, 127i16).unwrap()).into()),
-        Just(Array::random(shape.clone(), Uniform::new(-128i32, 127i32).unwrap()).into()),
-        Just(Array::random(shape.clone(), Uniform::new(-128i64, 127i64).unwrap()).into()),
-        Just(Array::random(shape.clone(), Uniform::new(-128f32, 127f32).unwrap()).into()),
-        Just(Array::random(shape.clone(), Uniform::new(-128f64, 127f64).unwrap()).into()),
+        Just(Array::random(shape, Uniform::new(0u8, 255u8).unwrap()).into()),
+        Just(Array::random(shape, Uniform::new(0u16, 255u16).unwrap()).into()),
+        Just(Array::random(shape, Uniform::new(0u32, 255u32).unwrap()).into()),
+        Just(Array::random(shape, Uniform::new(0u64, 255u64).unwrap()).into()),
+        Just(Array::random(shape, Uniform::new(-128i8, 127i8).unwrap()).into()),
+        Just(Array::random(shape, Uniform::new(-128i16, 127i16).unwrap()).into()),
+        Just(Array::random(shape, Uniform::new(-128i32, 127i32).unwrap()).into()),
+        Just(Array::random(shape, Uniform::new(-128i64, 127i64).unwrap()).into()),
+        Just(Array::random(shape, Uniform::new(-128f32, 127f32).unwrap()).into()),
+        Just(Array::random(shape, Uniform::new(-128f64, 127f64).unwrap()).into()),
         Just(
-            Array::random(shape.clone(), Uniform::new(0u8, 1u8).unwrap())
+            Array::random(shape, Uniform::new(0u8, 1u8).unwrap())
                 .mapv(|x| x == 1)
                 .into()
         ),
         Just(
-            Array::random(shape.clone(), Uniform::new(-1000f32, 1000f32).unwrap())
+            Array::random(shape, Uniform::new(-1000f32, 1000f32).unwrap())
                 .mapv(|x| x.to_string())
                 .into()
         ),
         Just(
-            Array::random(s.clone(), Uniform::new(0u8, 255u8).unwrap())
+            Array::random(s, Uniform::new(0u8, 255u8).unwrap())
                 .reversed_axes()
                 .into()
         ),
         Just(
-            Array::random(s.clone(), Uniform::new(0u16, 255u16).unwrap())
+            Array::random(s, Uniform::new(0u16, 255u16).unwrap())
                 .reversed_axes()
                 .into()
         ),
         Just(
-            Array::random(s.clone(), Uniform::new(0u32, 255u32).unwrap())
+            Array::random(s, Uniform::new(0u32, 255u32).unwrap())
                 .reversed_axes()
                 .into()
         ),
         Just(
-            Array::random(s.clone(), Uniform::new(0u64, 255u64).unwrap())
+            Array::random(s, Uniform::new(0u64, 255u64).unwrap())
                 .reversed_axes()
                 .into()
         ),
         Just(
-            Array::random(s.clone(), Uniform::new(-128i8, 127i8).unwrap())
+            Array::random(s, Uniform::new(-128i8, 127i8).unwrap())
                 .reversed_axes()
                 .into()
         ),
         Just(
-            Array::random(s.clone(), Uniform::new(-128i16, 127i16).unwrap())
+            Array::random(s, Uniform::new(-128i16, 127i16).unwrap())
                 .reversed_axes()
                 .into()
         ),
         Just(
-            Array::random(s.clone(), Uniform::new(-128i32, 127i32).unwrap())
+            Array::random(s, Uniform::new(-128i32, 127i32).unwrap())
                 .reversed_axes()
                 .into()
         ),
         Just(
-            Array::random(s.clone(), Uniform::new(-128i64, 127i64).unwrap())
+            Array::random(s, Uniform::new(-128i64, 127i64).unwrap())
                 .reversed_axes()
                 .into()
         ),
         Just(
-            Array::random(s.clone(), Uniform::new(-128f32, 127f32).unwrap())
+            Array::random(s, Uniform::new(-128f32, 127f32).unwrap())
                 .reversed_axes()
                 .into()
         ),
         Just(
-            Array::random(s.clone(), Uniform::new(-128f64, 127f64).unwrap())
+            Array::random(s, Uniform::new(-128f64, 127f64).unwrap())
                 .reversed_axes()
                 .into()
         ),
         Just(
-            Array::random(s.clone(), Uniform::new(0u8, 1u8).unwrap())
+            Array::random(s, Uniform::new(0u8, 1u8).unwrap())
                 .mapv(|x| x == 1)
                 .reversed_axes()
                 .into()
         ),
         Just(
-            Array::random(s.clone(), Uniform::new(-1000f32, 1000f32).unwrap())
+            Array::random(s, Uniform::new(-1000f32, 1000f32).unwrap())
                 .mapv(|x| x.to_string())
                 .reversed_axes()
                 .into()
@@ -314,9 +315,9 @@ pub fn select_strat(n: usize) -> BoxedStrategy<SelectInfoElem> {
     }
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// AnnData operations
-////////////////////////////////////////////////////////////////////////////////
+//-----------------------------------------------------------------------------
+// AnnData operations
+//-----------------------------------------------------------------------------
 
 pub fn anndata_eq<B1: Backend, B2: Backend>(
     adata1: &AnnData<B1>,
@@ -327,12 +328,12 @@ pub fn anndata_eq<B1: Backend, B2: Backend>(
         && adata1.obs_names() == adata2.obs_names()
         && adata1.var_names() == adata2.var_names()
         && {
-            let a = adata1.read_obs()?; 
+            let a = adata1.read_obs()?;
             let b = adata2.read_obs()?;
             a == b || (a.height() == 0 && b.height() == 0)
         }
         && {
-            let a = adata1.read_var()?; 
+            let a = adata1.read_var()?;
             let b = adata2.read_var()?;
             a == b || (a.height() == 0 && b.height() == 0)
         }
@@ -353,14 +354,15 @@ pub fn anndata_eq<B1: Backend, B2: Backend>(
             adata1.uns().get_item::<Data>(k).unwrap() == adata2.uns().get_item(k).unwrap()
         })
         && adata1.layers().keys().iter().all(|k| {
-            adata1.layers().get_item::<ArrayData>(k).unwrap() == adata2.layers().get_item(k).unwrap()
+            adata1.layers().get_item::<ArrayData>(k).unwrap()
+                == adata2.layers().get_item(k).unwrap()
         });
     Ok(is_equal)
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// Array operations
-////////////////////////////////////////////////////////////////////////////////
+//-----------------------------------------------------------------------------
+// Array operations
+//-----------------------------------------------------------------------------
 
 pub fn array_select(arr: &ArrayData, select: &[SelectInfoElem]) -> ArrayData {
     match arr {
@@ -492,7 +494,7 @@ where
 {
     let nrow = csr.nrows();
     let mat: DMatrix<T> = DMatrix::from(csr);
-    (0..nrow).into_iter().step_by(chunk_size).map(move |i| {
+    (0..nrow).step_by(chunk_size).map(move |i| {
         let j = (i + chunk_size).min(nrow);
         let m = mat.index((i..j, ..));
         CsrMatrix::from(&m)
@@ -515,7 +517,7 @@ fn dense_array_select<T: Clone, D: Dimension + RemoveAxis>(
     select: &[SelectInfoElem],
 ) -> Array<T, D> {
     let mut result = array.clone();
-    array.shape().into_iter().enumerate().for_each(|(i, &dim)| {
+    array.shape().iter().enumerate().for_each(|(i, &dim)| {
         let idx = SelectInfoElemBounds::new(&select[i], dim).to_vec();
         result = result.deref().select(Axis(i), idx.as_slice());
     });
@@ -531,8 +533,10 @@ where
     D: Dimension + RemoveAxis,
 {
     let nrow = array.shape()[0];
-    (0..nrow).into_iter().step_by(chunk_size).map(move |i| {
+    (0..nrow).step_by(chunk_size).map(move |i| {
         let j = (i + chunk_size).min(nrow);
-        array.deref().select(Axis(0), (i..j).collect::<Vec<_>>().as_slice())
+        array
+            .deref()
+            .select(Axis(0), (i..j).collect::<Vec<_>>().as_slice())
     })
 }

--- a/anndata-test-utils/src/common/mod.rs
+++ b/anndata-test-utils/src/common/mod.rs
@@ -72,19 +72,19 @@ pub fn anndata_strat<B: Backend, P: AsRef<Path> + Clone>(
             adata.set_obs_names(obs_names).unwrap();
             adata.set_var_names(var_names).unwrap();
             obsm.into_iter().enumerate().for_each(|(i, arr)| {
-                adata.obsm().add(&format!("varm_{}", i), arr).unwrap();
+                adata.obsm().add(&format!("varm_{i}"), arr).unwrap();
             });
             obsp.into_iter().enumerate().for_each(|(i, arr)| {
-                adata.obsp().add(&format!("obsp_{}", i), arr).unwrap();
+                adata.obsp().add(&format!("obsp_{i}"), arr).unwrap();
             });
             varm.into_iter().enumerate().for_each(|(i, arr)| {
-                adata.varm().add(&format!("varm_{}", i), arr).unwrap();
+                adata.varm().add(&format!("varm_{i}"), arr).unwrap();
             });
             varp.into_iter().enumerate().for_each(|(i, arr)| {
-                adata.varp().add(&format!("varp_{}", i), arr).unwrap();
+                adata.varp().add(&format!("varp_{i}"), arr).unwrap();
             });
             layers.into_iter().enumerate().for_each(|(i, arr)| {
-                adata.layers().add(&format!("layer_{}", i), arr).unwrap();
+                adata.layers().add(&format!("layer_{i}"), arr).unwrap();
             });
             adata
         },
@@ -95,7 +95,7 @@ pub fn index_strat(n: usize) -> BoxedStrategy<DataFrameIndex> {
     if n == 0 {
         Just(DataFrameIndex::empty()).boxed()
     } else {
-        let list = (0..n).map(|i| format!("i_{}", i)).collect();
+        let list = (0..n).map(|i| format!("i_{i}")).collect();
         let range = n.into();
         let interval = (0..n).prop_flat_map(move |i| {
             (Just(i), (0..n - i)).prop_flat_map(move |(a, b)| {

--- a/anndata-test-utils/src/lib.rs
+++ b/anndata-test-utils/src/lib.rs
@@ -30,7 +30,7 @@ pub fn test_save<B: Backend>() {
     with_tmp_dir(|dir| {
         let input = dir.join("input");
         let output = dir.join("output");
-        let anndatas = ((0 as usize..100), (0 as usize..100)).prop_flat_map(|(n_obs, n_vars)| {
+        let anndatas = ((0_usize..100), (0_usize..100)).prop_flat_map(|(n_obs, n_vars)| {
             (
                 anndata_strat::<B, _>(&input, n_obs, n_vars),
                 select_strat(n_obs),
@@ -94,7 +94,7 @@ where
         vec![1, 2, 3, 4, 5, 6, 7],
     )
     .unwrap();
-    adata.set_x(&CsrNonCanonical::from(&coo)).unwrap();
+    adata.set_x(CsrNonCanonical::from(&coo)).unwrap();
     assert!(adata.x().get::<CsrMatrix<i32>>().is_err());
     adata.x().get::<CsrNonCanonical<i32>>().unwrap().unwrap();
     adata.x().get::<ArrayData>().unwrap().unwrap();
@@ -106,7 +106,7 @@ where
     T: AnnDataOp,
 {
     let arrays =
-        proptest::collection::vec(0 as usize..50, 2..4).prop_flat_map(|shape| array_strat(&shape));
+        proptest::collection::vec(0_usize..50, 2..4).prop_flat_map(|shape| array_strat(&shape));
     proptest!(ProptestConfig::with_cases(256), |(x in arrays)| {
         let adata = adata_gen();
         adata.set_x(&x).unwrap();
@@ -119,7 +119,7 @@ where
     F: Fn() -> T,
     T: AnnDataOp,
 {
-    let arrays = proptest::collection::vec(0 as usize..50, 2..4)
+    let arrays = proptest::collection::vec(0_usize..50, 2..4)
         .prop_flat_map(|shape| array_slice_strat(&shape));
     proptest!(ProptestConfig::with_cases(256), |((x, select) in arrays)| {
         let adata = adata_gen();
@@ -143,7 +143,7 @@ where
     T: AnnDataOp,
 {
     let arrays =
-        proptest::collection::vec(20 as usize..50, 2..3).prop_flat_map(|shape| array_strat(&shape));
+        proptest::collection::vec(20_usize..50, 2..3).prop_flat_map(|shape| array_strat(&shape));
     proptest!(ProptestConfig::with_cases(10), |(x in arrays)| {
         if let ArrayData::CscMatrix(_) = x {
         } else {
@@ -163,10 +163,10 @@ pub fn test_concat<B: Backend>() {
         let input2 = dir.join("input2");
         let output = dir.join("output");
         let anndatas = (
-            (0 as usize..100),
-            (0 as usize..100),
-            (0 as usize..100),
-            (0 as usize..100),
+            (0_usize..100),
+            (0_usize..100),
+            (0_usize..100),
+            (0_usize..100),
         )
             .prop_flat_map(|(n_obs1, n_vars1, n_obs2, n_vars2)| {
                 (

--- a/anndata-test-utils/tests/tests.rs
+++ b/anndata-test-utils/tests/tests.rs
@@ -1,8 +1,8 @@
+use anndata::{AnnData, Backend};
+use anndata_hdf5::H5;
 use anndata_test_utils as utils;
 use anndata_test_utils::with_tmp_dir;
-use anndata_hdf5::H5;
 use anndata_zarr::Zarr;
-use anndata::{AnnData, Backend};
 
 #[test]
 fn test_basic() {
@@ -15,7 +15,7 @@ fn test_complex_dataframe() {
     let input = "tests/data/sample.h5ad";
     with_tmp_dir(|dir| {
         let file = dir.join("test.h5");
-        let adata = AnnData::<H5>::open(H5::open(&input).unwrap()).unwrap();
+        let adata = AnnData::<H5>::open(H5::open(input).unwrap()).unwrap();
         adata.write::<H5, _>(file, None, None).unwrap();
 
         let file = dir.join("test.zarr");
@@ -34,12 +34,11 @@ fn test_speacial_cases() {
     with_tmp_dir(|dir| {
         let file = dir.join("test.h5");
         let adata_gen = || AnnData::<H5>::new(&file).unwrap();
-        utils::test_speacial_cases(|| adata_gen());
+        utils::test_speacial_cases(adata_gen);
 
         let file = dir.join("test.zarr");
         let adata_gen = || AnnData::<Zarr>::new(&file).unwrap();
-        utils::test_speacial_cases(|| adata_gen());
-
+        utils::test_speacial_cases(adata_gen);
     })
 }
 
@@ -48,11 +47,11 @@ fn test_noncanonical() {
     with_tmp_dir(|dir| {
         let file = dir.join("test.h5");
         let adata_gen = || AnnData::<H5>::new(&file).unwrap();
-        utils::test_noncanonical(|| adata_gen());
+        utils::test_noncanonical(adata_gen);
 
         let file = dir.join("test.zarr");
         let adata_gen = || AnnData::<Zarr>::new(&file).unwrap();
-        utils::test_noncanonical(|| adata_gen());
+        utils::test_noncanonical(adata_gen);
     })
 }
 
@@ -61,7 +60,7 @@ fn test_io() {
     with_tmp_dir(|dir| {
         let file = dir.join("test.h5");
         let adata_gen = || AnnData::<H5>::new(&file).unwrap();
-        utils::test_io(|| adata_gen());
+        utils::test_io(adata_gen);
 
         //let file = dir.join("test.zarr");
         //let adata_gen = || AnnData::<Zarr>::new(&file).unwrap();
@@ -74,7 +73,7 @@ fn test_index() {
     with_tmp_dir(|dir| {
         let file = dir.join("test.h5");
         let adata_gen = || AnnData::<H5>::new(&file).unwrap();
-        utils::test_index(|| adata_gen());
+        utils::test_index(adata_gen);
 
         //let file = dir.join("test.zarr");
         //let adata_gen = || AnnData::<Zarr>::new(&file).unwrap();
@@ -87,10 +86,10 @@ fn test_iterator() {
     with_tmp_dir(|dir| {
         let file = dir.join("test.h5");
         let adata_gen = || AnnData::<H5>::new(&file).unwrap();
-        utils::test_iterator(|| adata_gen());
+        utils::test_iterator(adata_gen);
 
         let file = dir.join("test.zarr");
         let adata_gen = || AnnData::<Zarr>::new(&file).unwrap();
-        utils::test_iterator(|| adata_gen());
+        utils::test_iterator(adata_gen);
     })
 }

--- a/anndata-zarr/Cargo.toml
+++ b/anndata-zarr/Cargo.toml
@@ -23,3 +23,6 @@ tempfile = "3.2"
 proptest = "1"
 rand = "0.9"
 ndarray-rand = "0.16"
+
+[lints]
+workspace = true

--- a/anndata-zarr/src/lib.rs
+++ b/anndata-zarr/src/lib.rs
@@ -13,9 +13,13 @@ use std::{
 };
 use std::{sync::Arc, vec};
 use zarrs::array::{
-    ZARR_NAN_F32, ZARR_NAN_F64, codec::bytes_to_bytes::zstd::ZstdCodec, data_type::{
-        BoolDataType, Float32DataType, Float64DataType, Int8DataType, Int16DataType, Int32DataType, Int64DataType, StringDataType, UInt8DataType, UInt16DataType, UInt32DataType, UInt64DataType
-    }
+    codec::bytes_to_bytes::zstd::ZstdCodec,
+    data_type::{
+        BoolDataType, Float32DataType, Float64DataType, Int16DataType, Int32DataType,
+        Int64DataType, Int8DataType, StringDataType, UInt16DataType, UInt32DataType,
+        UInt64DataType, UInt8DataType,
+    },
+    ZARR_NAN_F32, ZARR_NAN_F64,
 };
 use zarrs::filesystem::FilesystemStore;
 use zarrs::group::Group;
@@ -122,7 +126,7 @@ impl GroupOp<Zarr> for ZarrStore {
         let result = self.list_dir(&StorePrefix::root())?;
         Ok(result
             .prefixes()
-            .into_iter()
+            .iter()
             .map(|x| x.as_str().trim_end_matches("/").to_string())
             .collect())
     }
@@ -198,7 +202,7 @@ impl GroupOp<Zarr> for ZarrGroup {
             .store
             .list_dir(&current_path.as_str().try_into()?)?
             .prefixes()
-            .into_iter()
+            .iter()
             .map(|x| {
                 x.as_str()
                     .strip_prefix(current_path.as_str())
@@ -381,11 +385,7 @@ impl DatasetOp<Zarr> for ZarrDataset {
     }
 
     fn shape(&self) -> Shape {
-        self.dataset
-            .shape()
-            .into_iter()
-            .map(|x| *x as usize)
-            .collect()
+        self.dataset.shape().iter().map(|x| *x as usize).collect()
     }
 
     fn reshape(&mut self, shape: &Shape) -> Result<()> {
@@ -484,9 +484,13 @@ impl DatasetOp<Zarr> for ZarrDataset {
                 .collect();
             if starts.len() == selection.ndim() {
                 container.cache.clear();
-                container
-                    .dataset
-                    .store_array_subset(&ArraySubset::new_with_start_shape(starts, arr.shape().iter().map(|x| *x as u64).collect())?, arr.to_owned())?;
+                container.dataset.store_array_subset(
+                    &ArraySubset::new_with_start_shape(
+                        starts,
+                        arr.shape().iter().map(|x| *x as u64).collect(),
+                    )?,
+                    arr.to_owned(),
+                )?;
             } else {
                 panic!("Not implemented");
             }
@@ -519,9 +523,9 @@ where
     let arr = arr.into_dyn();
     let slices = info
         .as_ref()
-        .into_iter()
+        .iter()
         .map(|x| match x.as_ref() {
-            SelectInfoElem::Slice(slice) => Some(SliceInfoElem::from(slice.clone())),
+            SelectInfoElem::Slice(slice) => Some(SliceInfoElem::from(*slice)),
             _ => None,
         })
         .collect::<Option<Vec<_>>>();
@@ -531,16 +535,13 @@ where
         let shape = arr.shape();
         let select: Vec<_> = info
             .as_ref()
-            .into_iter()
+            .iter()
             .zip(shape)
             .map(|(x, n)| SelectInfoElemBounds::new(x.as_ref(), *n))
             .collect();
         let new_shape = select.iter().map(|x| x.len()).collect::<Vec<_>>();
         ArrayD::from_shape_fn(new_shape, |idx| {
-            let new_idx: Vec<_> = (0..idx.ndim())
-                .into_iter()
-                .map(|i| select[i].index(idx[i]))
-                .collect();
+            let new_idx: Vec<_> = (0..idx.ndim()).map(|i| select[i].index(idx[i])).collect();
             arr.index(new_idx.as_slice()).clone()
         })
     }
@@ -608,14 +609,14 @@ fn new_empty_dataset_helper<T: BackendData, S: ?Sized>(
     let chunk_size: Vec<u64> = match config.block_size {
         Some(s) => s
             .as_ref()
-            .into_iter()
+            .iter()
             .map(|x| (*x).max(1) as u64)
             .collect::<Vec<_>>(),
         _ => {
             if shape.len() == 1 {
-                vec![shape[0].min(16384).max(1) as u64]
+                vec![shape[0].clamp(1, 16384) as u64]
             } else {
-                shape.iter().map(|&x| x.min(128).max(1) as u64).collect()
+                shape.iter().map(|&x| x.clamp(1, 128) as u64).collect()
             }
         }
     };

--- a/anndata-zarr/src/lib.rs
+++ b/anndata-zarr/src/lib.rs
@@ -187,7 +187,7 @@ impl GroupOp<Zarr> for ZarrStore {
 
     /// Check if a group or dataset exists.
     fn exists(&self, name: &str) -> Result<bool> {
-        let path = format!("/{}", name);
+        let path = format!("/{name}");
         Ok(zarrs::node::node_exists(
             &self.inner,
             &path.as_str().try_into()?,
@@ -318,7 +318,7 @@ impl AttributeOp<Zarr> for ZarrGroup {
             .group
             .attributes()
             .get(name)
-            .with_context(|| format!("Attribute {} not found", name))?
+            .with_context(|| format!("Attribute {name} not found"))?
             .clone())
     }
 }
@@ -348,7 +348,7 @@ impl AttributeOp<Zarr> for ZarrDataset {
             .dataset
             .attributes()
             .get(name)
-            .with_context(|| format!("Attribute {} not found", name))?
+            .with_context(|| format!("Attribute {name} not found"))?
             .clone())
     }
 }
@@ -562,7 +562,7 @@ fn canoincalize_path<'a>(path: &'a str) -> Cow<'a, str> {
     if path.starts_with("/") {
         path.into()
     } else {
-        format!("/{}", path).into()
+        format!("/{path}").into()
     }
 }
 

--- a/anndata/Cargo.toml
+++ b/anndata/Cargo.toml
@@ -34,3 +34,6 @@ proptest = "1"
 rand = "0.8.5"
 ndarray-rand = "0.16"
 nalgebra = { version = "0.34", features = ["rand"] }
+
+[lints]
+workspace = true

--- a/anndata/src/anndata.rs
+++ b/anndata/src/anndata.rs
@@ -75,32 +75,32 @@ impl<B: Backend> std::fmt::Display for AnnData<B> {
         if let Some(keys) = self.uns.lock().as_ref().map(|x| x.keys().join("', '"))
             && !keys.is_empty()
         {
-            write!(f, "\n    uns: '{}'", keys)?;
+            write!(f, "\n    uns: '{keys}'")?;
         }
         if let Some(keys) = self.obsm.lock().as_ref().map(|x| x.keys().join("', '"))
             && !keys.is_empty()
         {
-            write!(f, "\n    obsm: '{}'", keys)?;
+            write!(f, "\n    obsm: '{keys}'")?;
         }
         if let Some(keys) = self.obsp.lock().as_ref().map(|x| x.keys().join("', '"))
             && !keys.is_empty()
         {
-            write!(f, "\n    obsp: '{}'", keys)?;
+            write!(f, "\n    obsp: '{keys}'")?;
         }
         if let Some(keys) = self.varm.lock().as_ref().map(|x| x.keys().join("', '"))
             && !keys.is_empty()
         {
-            write!(f, "\n    varm: '{}'", keys)?;
+            write!(f, "\n    varm: '{keys}'")?;
         }
         if let Some(keys) = self.varp.lock().as_ref().map(|x| x.keys().join("', '"))
             && !keys.is_empty()
         {
-            write!(f, "\n    varp: '{}'", keys)?;
+            write!(f, "\n    varp: '{keys}'")?;
         }
         if let Some(keys) = self.layers.lock().as_ref().map(|x| x.keys().join("', '"))
             && !keys.is_empty()
         {
-            write!(f, "\n    layers: '{}'", keys)?;
+            write!(f, "\n    layers: '{keys}'")?;
         }
         Ok(())
     }

--- a/anndata/src/anndata.rs
+++ b/anndata/src/anndata.rs
@@ -60,47 +60,47 @@ impl<B: Backend> std::fmt::Display for AnnData<B> {
             "AnnData object with n_obs x n_vars = {} x {} backed at '{}'",
             self.n_obs(),
             self.n_vars(),
-            self.filename().to_str().unwrap().to_string(),
+            self.filename().to_str().unwrap(),
         )?;
-        if let Some(obs) = self.obs.lock().as_ref().map(|x| x.get_column_names()) {
-            if !obs.is_empty() {
-                write!(f, "\n    obs: '{}'", obs.into_iter().join("', '"))?;
-            }
+        if let Some(obs) = self.obs.lock().as_ref().map(|x| x.get_column_names())
+            && !obs.is_empty()
+        {
+            write!(f, "\n    obs: '{}'", obs.into_iter().join("', '"))?;
         }
-        if let Some(var) = self.var.lock().as_ref().map(|x| x.get_column_names()) {
-            if !var.is_empty() {
-                write!(f, "\n    var: '{}'", var.into_iter().join("', '"))?;
-            }
+        if let Some(var) = self.var.lock().as_ref().map(|x| x.get_column_names())
+            && !var.is_empty()
+        {
+            write!(f, "\n    var: '{}'", var.into_iter().join("', '"))?;
         }
-        if let Some(keys) = self.uns.lock().as_ref().map(|x| x.keys().join("', '")) {
-            if !keys.is_empty() {
-                write!(f, "\n    uns: '{}'", keys)?;
-            }
+        if let Some(keys) = self.uns.lock().as_ref().map(|x| x.keys().join("', '"))
+            && !keys.is_empty()
+        {
+            write!(f, "\n    uns: '{}'", keys)?;
         }
-        if let Some(keys) = self.obsm.lock().as_ref().map(|x| x.keys().join("', '")) {
-            if !keys.is_empty() {
-                write!(f, "\n    obsm: '{}'", keys)?;
-            }
+        if let Some(keys) = self.obsm.lock().as_ref().map(|x| x.keys().join("', '"))
+            && !keys.is_empty()
+        {
+            write!(f, "\n    obsm: '{}'", keys)?;
         }
-        if let Some(keys) = self.obsp.lock().as_ref().map(|x| x.keys().join("', '")) {
-            if !keys.is_empty() {
-                write!(f, "\n    obsp: '{}'", keys)?;
-            }
+        if let Some(keys) = self.obsp.lock().as_ref().map(|x| x.keys().join("', '"))
+            && !keys.is_empty()
+        {
+            write!(f, "\n    obsp: '{}'", keys)?;
         }
-        if let Some(keys) = self.varm.lock().as_ref().map(|x| x.keys().join("', '")) {
-            if !keys.is_empty() {
-                write!(f, "\n    varm: '{}'", keys)?;
-            }
+        if let Some(keys) = self.varm.lock().as_ref().map(|x| x.keys().join("', '"))
+            && !keys.is_empty()
+        {
+            write!(f, "\n    varm: '{}'", keys)?;
         }
-        if let Some(keys) = self.varp.lock().as_ref().map(|x| x.keys().join("', '")) {
-            if !keys.is_empty() {
-                write!(f, "\n    varp: '{}'", keys)?;
-            }
+        if let Some(keys) = self.varp.lock().as_ref().map(|x| x.keys().join("', '"))
+            && !keys.is_empty()
+        {
+            write!(f, "\n    varp: '{}'", keys)?;
         }
-        if let Some(keys) = self.layers.lock().as_ref().map(|x| x.keys().join("', '")) {
-            if !keys.is_empty() {
-                write!(f, "\n    layers: '{}'", keys)?;
-            }
+        if let Some(keys) = self.layers.lock().as_ref().map(|x| x.keys().join("', '"))
+            && !keys.is_empty()
+        {
+            write!(f, "\n    layers: '{}'", keys)?;
         }
         Ok(())
     }
@@ -228,11 +228,11 @@ impl<B: Backend> AnnData<B> {
     ///
     /// * `filename` - The path to the output file.
     /// * `partial` - If Some, writes only the specified fields. If None, writes all fields.
-    ///             This can be useful for saving space when only a subset of the data is needed.
-    ///             Possible fields are: "X", "obs", "var", "obsm", "obsp", "varm", "varp", "uns", "layers".
+    ///   This can be useful for saving space when only a subset of the data is needed.
+    ///   Possible fields are: "X", "obs", "var", "obsm", "obsp", "varm", "varp", "uns", "layers".
     /// * `chunk_size` - If None, writes the entire data matrix at once. Otherwise,
-    ///                  writes the data matrix in chunks of the specified size.
-    ///              This can be useful for saving large datasets that do not fit into memory.
+    ///   writes the data matrix in chunks of the specified size.
+    ///   This can be useful for saving large datasets that do not fit into memory.
     pub fn write<O: Backend, P: AsRef<Path>>(
         &self,
         filename: P,

--- a/anndata/src/anndata/dataset.rs
+++ b/anndata/src/anndata/dataset.rs
@@ -68,7 +68,7 @@ impl<B: Backend> std::fmt::Display for AnnDataSet<B> {
             .map(|x| x.keys().join("', '"))
             && !keys.is_empty()
         {
-            write!(f, "\n    uns: '{}'", keys)?;
+            write!(f, "\n    uns: '{keys}'")?;
         }
         if let Some(keys) = self
             .annotation
@@ -78,7 +78,7 @@ impl<B: Backend> std::fmt::Display for AnnDataSet<B> {
             .map(|x| x.keys().join("', '"))
             && !keys.is_empty()
         {
-            write!(f, "\n    obsm: '{}'", keys)?;
+            write!(f, "\n    obsm: '{keys}'")?;
         }
         if let Some(keys) = self
             .annotation
@@ -88,7 +88,7 @@ impl<B: Backend> std::fmt::Display for AnnDataSet<B> {
             .map(|x| x.keys().join("', '"))
             && !keys.is_empty()
         {
-            write!(f, "\n    obsp: '{}'", keys)?;
+            write!(f, "\n    obsp: '{keys}'")?;
         }
         if let Some(keys) = self
             .annotation
@@ -98,7 +98,7 @@ impl<B: Backend> std::fmt::Display for AnnDataSet<B> {
             .map(|x| x.keys().join("', '"))
             && !keys.is_empty()
         {
-            write!(f, "\n    varm: '{}'", keys)?;
+            write!(f, "\n    varm: '{keys}'")?;
         }
         if let Some(keys) = self
             .annotation
@@ -108,7 +108,7 @@ impl<B: Backend> std::fmt::Display for AnnDataSet<B> {
             .map(|x| x.keys().join("', '"))
             && !keys.is_empty()
         {
-            write!(f, "\n    varp: '{}'", keys)?;
+            write!(f, "\n    varp: '{keys}'")?;
         }
         Ok(())
     }

--- a/anndata/src/anndata/dataset.rs
+++ b/anndata/src/anndata/dataset.rs
@@ -37,7 +37,7 @@ impl<B: Backend> std::fmt::Display for AnnDataSet<B> {
             self.annotation.filename().display(),
         )?;
         let adatas = self.anndatas.inner();
-        if adatas.len() > 0 {
+        if !adatas.is_empty() {
             write!(f, "\ncontains {} AnnData objects", adatas.len(),)?;
         }
         if let Some(obs) = self
@@ -46,10 +46,9 @@ impl<B: Backend> std::fmt::Display for AnnDataSet<B> {
             .lock()
             .as_ref()
             .map(|x| x.get_column_names())
+            && !obs.is_empty()
         {
-            if !obs.is_empty() {
-                write!(f, "\n    obs: '{}'", obs.into_iter().join("', '"))?;
-            }
+            write!(f, "\n    obs: '{}'", obs.into_iter().join("', '"))?;
         }
         if let Some(var) = self
             .annotation
@@ -57,10 +56,9 @@ impl<B: Backend> std::fmt::Display for AnnDataSet<B> {
             .lock()
             .as_ref()
             .map(|x| x.get_column_names())
+            && !var.is_empty()
         {
-            if !var.is_empty() {
-                write!(f, "\n    var: '{}'", var.into_iter().join("', '"))?;
-            }
+            write!(f, "\n    var: '{}'", var.into_iter().join("', '"))?;
         }
         if let Some(keys) = self
             .annotation
@@ -68,10 +66,9 @@ impl<B: Backend> std::fmt::Display for AnnDataSet<B> {
             .lock()
             .as_ref()
             .map(|x| x.keys().join("', '"))
+            && !keys.is_empty()
         {
-            if !keys.is_empty() {
-                write!(f, "\n    uns: '{}'", keys)?;
-            }
+            write!(f, "\n    uns: '{}'", keys)?;
         }
         if let Some(keys) = self
             .annotation
@@ -79,10 +76,9 @@ impl<B: Backend> std::fmt::Display for AnnDataSet<B> {
             .lock()
             .as_ref()
             .map(|x| x.keys().join("', '"))
+            && !keys.is_empty()
         {
-            if !keys.is_empty() {
-                write!(f, "\n    obsm: '{}'", keys)?;
-            }
+            write!(f, "\n    obsm: '{}'", keys)?;
         }
         if let Some(keys) = self
             .annotation
@@ -90,10 +86,9 @@ impl<B: Backend> std::fmt::Display for AnnDataSet<B> {
             .lock()
             .as_ref()
             .map(|x| x.keys().join("', '"))
+            && !keys.is_empty()
         {
-            if !keys.is_empty() {
-                write!(f, "\n    obsp: '{}'", keys)?;
-            }
+            write!(f, "\n    obsp: '{}'", keys)?;
         }
         if let Some(keys) = self
             .annotation
@@ -101,10 +96,9 @@ impl<B: Backend> std::fmt::Display for AnnDataSet<B> {
             .lock()
             .as_ref()
             .map(|x| x.keys().join("', '"))
+            && !keys.is_empty()
         {
-            if !keys.is_empty() {
-                write!(f, "\n    varm: '{}'", keys)?;
-            }
+            write!(f, "\n    varm: '{}'", keys)?;
         }
         if let Some(keys) = self
             .annotation
@@ -112,10 +106,9 @@ impl<B: Backend> std::fmt::Display for AnnDataSet<B> {
             .lock()
             .as_ref()
             .map(|x| x.keys().join("', '"))
+            && !keys.is_empty()
         {
-            if !keys.is_empty() {
-                write!(f, "\n    varp: '{}'", keys)?;
-            }
+            write!(f, "\n    varp: '{}'", keys)?;
         }
         Ok(())
     }
@@ -130,7 +123,7 @@ impl<B: Backend> AnnDataSet<B> {
         &self.annotation
     }
 
-    pub fn new<'a, T, S, P>(
+    pub fn new<T, S, P>(
         data: T,
         filename: P,
         add_key: &str,
@@ -218,10 +211,9 @@ impl<B: Backend> AnnDataSet<B> {
                 .map(|x| x.get_item::<Data>(&key).unwrap().unwrap())
                 .all_equal()
             {
-                annotation.uns().add(
-                    &key,
-                    uns.iter().next().unwrap().get_item::<Data>(&key)?.unwrap(),
-                )?;
+                annotation
+                    .uns()
+                    .add(&key, uns.first().unwrap().get_item::<Data>(&key)?.unwrap())?;
             }
         }
 
@@ -475,6 +467,10 @@ impl<B: Backend> StackedAnnData<B> {
 
     pub fn len(&self) -> usize {
         self.files.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
     }
 }
 

--- a/anndata/src/anndata/elem_io.rs
+++ b/anndata/src/anndata/elem_io.rs
@@ -1,13 +1,15 @@
 use crate::{
-    DataFrameElem, backend::{Backend, DataContainer, GroupOp}, container::{Axis, AxisArrays, Dim, Slot}, data::MAPPING_ENCODING
+    DataFrameElem,
+    backend::{Backend, DataContainer, GroupOp},
+    container::{Axis, AxisArrays, Dim, Slot},
+    data::MAPPING_ENCODING,
 };
 
 use anyhow::Result;
 
 pub(crate) fn open_df<B: Backend>(root: &B::Store, name: &str) -> Result<DataFrameElem<B>> {
     let df = if root.exists(name)? {
-        let obs = DataFrameElem::try_from(DataContainer::open(root, "obs")?)?;
-        obs
+        DataFrameElem::try_from(DataContainer::open(root, "obs")?)?
     } else {
         Slot::none()
     };
@@ -25,12 +27,18 @@ pub(crate) fn open_obsp<B: Backend>(group: B::Group, n_obs: Option<&Dim>) -> Res
 }
 
 // Helper function to create a new variable matrix (varm)
-pub(crate) fn open_varm<B: Backend>(group: B::Group, n_vars: Option<&Dim>) -> Result<AxisArrays<B>> {
+pub(crate) fn open_varm<B: Backend>(
+    group: B::Group,
+    n_vars: Option<&Dim>,
+) -> Result<AxisArrays<B>> {
     AxisArrays::new(group, Axis::Row, n_vars, None)
 }
 
 // Helper function to create a new pairwise variable matrix (varp)
-pub(crate) fn open_varp<B: Backend>(group: B::Group, n_vars: Option<&Dim>) -> Result<AxisArrays<B>> {
+pub(crate) fn open_varp<B: Backend>(
+    group: B::Group,
+    n_vars: Option<&Dim>,
+) -> Result<AxisArrays<B>> {
     AxisArrays::new(group, Axis::Pairwise, n_vars, None)
 }
 

--- a/anndata/src/backend.rs
+++ b/anndata/src/backend.rs
@@ -306,13 +306,12 @@ impl<B: Backend> DataContainer<B> {
                     .map(DataContainer::Group)
                     .map_err(|e2| {
                         e2.context(e1).context(format!(
-                            "Error opening group or dataset named '{}' in group",
-                            name
+                            "Error opening group or dataset named '{name}' in group"
                         ))
                     }),
             }
         } else {
-            bail!("No group or dataset named '{}' in group", name);
+            bail!("No group or dataset named '{name}' in group");
         }
     }
 

--- a/anndata/src/backend.rs
+++ b/anndata/src/backend.rs
@@ -2,13 +2,13 @@ mod datatype;
 use crate::data::{ArrayConvert, DynArray, SelectInfo, SelectInfoElem, Shape};
 pub use datatype::{BackendData, DataType, ScalarType};
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use core::fmt::{Debug, Formatter};
-use ndarray::{arr0, Array, CowArray, Dimension, Ix0, IxDyn};
-use std::path::{Path, PathBuf};
-use std::cell::RefCell;
-pub use serde_json::Value;
+use ndarray::{Array, CowArray, Dimension, Ix0, IxDyn, arr0};
 use serde::Deserialize;
+pub use serde_json::Value;
+use std::cell::RefCell;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Compression {
@@ -125,7 +125,7 @@ pub trait GroupOp<B: Backend + ?Sized> {
             None
         };
         let new_config = WriteConfig {
-            compression: compression,
+            compression,
             block_size: Some(block_size),
         };
         let dataset = self.new_empty_dataset::<D>(name, &shape.into(), new_config)?;
@@ -164,7 +164,7 @@ pub trait AttributeOp<B: Backend + ?Sized> {
 }
 
 pub trait DatasetOp<B: Backend + ?Sized> {
-    /// Required methods
+    // Required methods
 
     fn dtype(&self) -> Result<ScalarType>;
     fn shape(&self) -> Shape;
@@ -181,11 +181,11 @@ pub trait DatasetOp<B: Backend + ?Sized> {
         S: AsRef<SelectInfoElem>,
         D: Dimension;
 
-    /// Optional methods
+    // Optional methods
 
     fn read_dyn_array_slice<S>(&self, selection: &[S]) -> Result<DynArray>
     where
-        S: AsRef<SelectInfoElem>
+        S: AsRef<SelectInfoElem>,
     {
         let arr = match self.dtype()? {
             ScalarType::I8 => self.read_array_slice::<i8, _, IxDyn>(selection)?.into(),
@@ -208,7 +208,7 @@ pub trait DatasetOp<B: Backend + ?Sized> {
     where
         DynArray: ArrayConvert<Array<T, D>>,
         D: Dimension,
-        S: AsRef<SelectInfoElem>
+        S: AsRef<SelectInfoElem>,
     {
         self.read_dyn_array_slice(selection)?.try_convert()
     }
@@ -246,16 +246,12 @@ pub trait DatasetOp<B: Backend + ?Sized> {
     }
 }
 
+#[derive(Default)]
 pub enum DataContainer<B: Backend> {
     Group(B::Group),
     Dataset(B::Dataset),
+    #[default]
     Null,
-}
-
-impl<B: Backend> Default for DataContainer<B> {
-    fn default() -> Self {
-        DataContainer::Null
-    }
 }
 
 impl<B: Backend> Debug for DataContainer<B> {
@@ -284,8 +280,7 @@ impl<B: Backend> AttributeOp<B> for DataContainer<B> {
         }
     }
 
-    fn new_json_attr(&mut self, name: &str, value: &Value) -> Result<()>
-    {
+    fn new_json_attr(&mut self, name: &str, value: &Value) -> Result<()> {
         match self {
             DataContainer::Group(g) => g.new_json_attr(name, value),
             DataContainer::Dataset(d) => d.new_json_attr(name, value),
@@ -306,14 +301,15 @@ impl<B: Backend> DataContainer<B> {
         if group.exists(name)? {
             match group.open_dataset(name) {
                 Ok(gr) => Ok(DataContainer::Dataset(gr)),
-                Err(e1) => {
-                    group.open_group(name).map(DataContainer::Group).map_err(|e2|
+                Err(e1) => group
+                    .open_group(name)
+                    .map(DataContainer::Group)
+                    .map_err(|e2| {
                         e2.context(e1).context(format!(
                             "Error opening group or dataset named '{}' in group",
                             name
                         ))
-                    )
-                }
+                    }),
             }
         } else {
             bail!("No group or dataset named '{}' in group", name);
@@ -353,21 +349,21 @@ impl<B: Backend> DataContainer<B> {
             "dataframe" => DataType::DataFrame,
             "mapping" | "dict" => DataType::Mapping,
             "nullable-integer" | "nullable-boolean" => DataType::NullableArray,
-            ty => bail!("the anndata file contains an unsupported encoding type: '{}'", ty),
+            ty => bail!("the anndata file contains an unsupported encoding type: '{ty}'"),
         };
         Ok(ty)
     }
 
     pub fn as_group(&self) -> Result<&B::Group> {
         match self {
-            Self::Group(x) => Ok(&x),
+            Self::Group(x) => Ok(x),
             _ => bail!("Expecting Group"),
         }
     }
 
     pub fn as_dataset(&self) -> Result<&B::Dataset> {
         match self {
-            Self::Dataset(x) => Ok(&x),
+            Self::Dataset(x) => Ok(x),
             _ => bail!("Expecting Dataset"),
         }
     }

--- a/anndata/src/backend/datatype.rs
+++ b/anndata/src/backend/datatype.rs
@@ -33,12 +33,12 @@ impl DataType {
 impl Display for DataType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            DataType::Array(t) => write!(f, "Array({})", t),
+            DataType::Array(t) => write!(f, "Array({t})"),
             DataType::Categorical => write!(f, "Categorical"),
-            DataType::CsrMatrix(t) => write!(f, "CsrMatrix({})", t),
-            DataType::CscMatrix(t) => write!(f, "CscMatrix({})", t),
+            DataType::CsrMatrix(t) => write!(f, "CsrMatrix({t})"),
+            DataType::CscMatrix(t) => write!(f, "CscMatrix({t})"),
             DataType::DataFrame => write!(f, "DataFrame"),
-            DataType::Scalar(t) => write!(f, "Scalar({})", t),
+            DataType::Scalar(t) => write!(f, "Scalar({t})"),
             DataType::Mapping => write!(f, "Mapping"),
             DataType::NullableArray => write!(f, "Nullable array"),
         }

--- a/anndata/src/backend/datatype.rs
+++ b/anndata/src/backend/datatype.rs
@@ -1,9 +1,9 @@
 use crate::data::{DynArray, DynCowArray, DynScalar};
 
-use anyhow::{bail, Result};
-use core::fmt::{Display, Formatter, Debug};
+use anyhow::{Result, bail};
+use core::fmt::{Debug, Display, Formatter};
 use ndarray::{ArrayD, CowArray, IxDyn};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// All data types that can be stored in an AnnData object.
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -64,11 +64,33 @@ pub enum ScalarType {
 
 impl ScalarType {
     pub fn is_numeric(&self) -> bool {
-        matches!(self, ScalarType::I8 | ScalarType::I16 | ScalarType::I32 | ScalarType::I64 | ScalarType::U8 | ScalarType::U16 | ScalarType::U32 | ScalarType::U64 | ScalarType::F32 | ScalarType::F64)
+        matches!(
+            self,
+            ScalarType::I8
+                | ScalarType::I16
+                | ScalarType::I32
+                | ScalarType::I64
+                | ScalarType::U8
+                | ScalarType::U16
+                | ScalarType::U32
+                | ScalarType::U64
+                | ScalarType::F32
+                | ScalarType::F64
+        )
     }
 
     pub fn is_integer(&self) -> bool {
-        matches!(self, ScalarType::I8 | ScalarType::I16 | ScalarType::I32 | ScalarType::I64 | ScalarType::U8 | ScalarType::U16 | ScalarType::U32 | ScalarType::U64)
+        matches!(
+            self,
+            ScalarType::I8
+                | ScalarType::I16
+                | ScalarType::I32
+                | ScalarType::I64
+                | ScalarType::U8
+                | ScalarType::U16
+                | ScalarType::U32
+                | ScalarType::U64
+        )
     }
 
     pub fn is_floating(&self) -> bool {
@@ -108,7 +130,13 @@ pub trait BackendData: Serialize + for<'a> Deserialize<'a> + Send + Sync + Clone
     const DTYPE: ScalarType;
 
     /// Convert to opaque representation.
-    fn into_dyn(&self) -> DynScalar;
+    fn as_dyn(&self) -> DynScalar;
+
+    #[deprecated]
+    #[allow(clippy::wrong_self_convention)]
+    fn into_dyn(&self) -> DynScalar {
+        self.as_dyn()
+    }
 
     /// Convert to opaque array representation.
     fn into_dyn_arr<'a>(arr: CowArray<'a, Self, IxDyn>) -> DynCowArray<'a>;
@@ -123,7 +151,7 @@ pub trait BackendData: Serialize + for<'a> Deserialize<'a> + Send + Sync + Clone
 impl BackendData for i8 {
     const DTYPE: ScalarType = ScalarType::I8;
 
-    fn into_dyn(&self) -> DynScalar {
+    fn as_dyn(&self) -> DynScalar {
         DynScalar::I8(*self)
     }
 
@@ -151,7 +179,7 @@ impl BackendData for i8 {
 impl BackendData for i16 {
     const DTYPE: ScalarType = ScalarType::I16;
 
-    fn into_dyn(&self) -> DynScalar {
+    fn as_dyn(&self) -> DynScalar {
         DynScalar::I16(*self)
     }
 
@@ -179,7 +207,7 @@ impl BackendData for i16 {
 impl BackendData for i32 {
     const DTYPE: ScalarType = ScalarType::I32;
 
-    fn into_dyn(&self) -> DynScalar {
+    fn as_dyn(&self) -> DynScalar {
         DynScalar::I32(*self)
     }
 
@@ -207,7 +235,7 @@ impl BackendData for i32 {
 impl BackendData for i64 {
     const DTYPE: ScalarType = ScalarType::I64;
 
-    fn into_dyn(&self) -> DynScalar {
+    fn as_dyn(&self) -> DynScalar {
         DynScalar::I64(*self)
     }
 
@@ -235,7 +263,7 @@ impl BackendData for i64 {
 impl BackendData for u8 {
     const DTYPE: ScalarType = ScalarType::U8;
 
-    fn into_dyn(&self) -> DynScalar {
+    fn as_dyn(&self) -> DynScalar {
         DynScalar::U8(*self)
     }
 
@@ -263,7 +291,7 @@ impl BackendData for u8 {
 impl BackendData for u16 {
     const DTYPE: ScalarType = ScalarType::U16;
 
-    fn into_dyn(&self) -> DynScalar {
+    fn as_dyn(&self) -> DynScalar {
         DynScalar::U16(*self)
     }
 
@@ -291,7 +319,7 @@ impl BackendData for u16 {
 impl BackendData for u32 {
     const DTYPE: ScalarType = ScalarType::U32;
 
-    fn into_dyn(&self) -> DynScalar {
+    fn as_dyn(&self) -> DynScalar {
         DynScalar::U32(*self)
     }
 
@@ -319,7 +347,7 @@ impl BackendData for u32 {
 impl BackendData for u64 {
     const DTYPE: ScalarType = ScalarType::U64;
 
-    fn into_dyn(&self) -> DynScalar {
+    fn as_dyn(&self) -> DynScalar {
         DynScalar::U64(*self)
     }
 
@@ -347,7 +375,7 @@ impl BackendData for u64 {
 impl BackendData for f32 {
     const DTYPE: ScalarType = ScalarType::F32;
 
-    fn into_dyn(&self) -> DynScalar {
+    fn as_dyn(&self) -> DynScalar {
         DynScalar::F32(*self)
     }
 
@@ -375,7 +403,7 @@ impl BackendData for f32 {
 impl BackendData for f64 {
     const DTYPE: ScalarType = ScalarType::F64;
 
-    fn into_dyn(&self) -> DynScalar {
+    fn as_dyn(&self) -> DynScalar {
         DynScalar::F64(*self)
     }
 
@@ -403,7 +431,7 @@ impl BackendData for f64 {
 impl BackendData for String {
     const DTYPE: ScalarType = ScalarType::String;
 
-    fn into_dyn(&self) -> DynScalar {
+    fn as_dyn(&self) -> DynScalar {
         DynScalar::String(self.clone())
     }
 
@@ -431,7 +459,7 @@ impl BackendData for String {
 impl BackendData for bool {
     const DTYPE: ScalarType = ScalarType::Bool;
 
-    fn into_dyn(&self) -> DynScalar {
+    fn as_dyn(&self) -> DynScalar {
         DynScalar::Bool(*self)
     }
 

--- a/anndata/src/concat.rs
+++ b/anndata/src/concat.rs
@@ -343,7 +343,7 @@ fn concat_axis_arrays<A: AxisArraysOp>(
     let size = axis_arrays[0].get(key).unwrap().shape().unwrap()[1];
     axis_arrays.iter().map(move |arr| {
         let arr: ArrayData = arr.get_item(key).unwrap().unwrap();
-        assert_eq!(arr.shape()[1], size, "dimension mismatch for key: {}", key);
+        assert_eq!(arr.shape()[1], size, "dimension mismatch for key: {key}");
         arr
     })
 }

--- a/anndata/src/concat.rs
+++ b/anndata/src/concat.rs
@@ -1,5 +1,5 @@
 use crate::data::utils::{array_major_minor_index_default, cs_major_minor_index2};
-use crate::data::{DataFrameIndex, DynCsrMatrix, Data, ArrayData, DynArray};
+use crate::data::{ArrayData, Data, DataFrameIndex, DynArray, DynCsrMatrix};
 use crate::{AnnDataOp, ArrayElemOp, AxisArraysOp, ElemCollectionOp, HasShape};
 use anyhow::{Result, ensure};
 use indexmap::IndexSet;
@@ -19,7 +19,7 @@ pub enum JoinType {
 }
 
 /// Concatenate multiple AnnData objects into one.
-/// 
+///
 /// This function concatenates multiple AnnData objects along the observation axis (`obs`),
 /// aligning the variable axis (`var`) according to the specified join type (inner or outer).
 /// It also concatenates associated data structures such as `obsm`, `obsp`, `layers`, and shared `uns` elements.
@@ -168,10 +168,8 @@ where
                 .map(|x| x.get_item::<Data>(&key).unwrap().unwrap())
                 .all_equal()
             {
-                out.uns().add(
-                    &key,
-                    uns.iter().next().unwrap().get_item::<Data>(&key)?.unwrap(),
-                )?;
+                out.uns()
+                    .add(&key, uns.first().unwrap().get_item::<Data>(&key)?.unwrap())?;
             }
         }
     }
@@ -266,7 +264,7 @@ fn align_series(
                     }
                 })
                 .collect();
-            Series::from_any_values_and_dtype(name.clone(), &values?, &dtype, false)?
+            Series::from_any_values_and_dtype(name.clone(), &values?, dtype, false)?
         }
     };
     Ok(new_series.into())
@@ -329,10 +327,7 @@ fn concat_x<A: AnnDataOp>(
         let arr = adata.x().get().unwrap().unwrap();
         index_array(
             arr,
-            &(0..adata.n_obs())
-                .into_iter()
-                .map(|x| Some(x))
-                .collect::<Vec<_>>(),
+            &(0..adata.n_obs()).map(Some).collect::<Vec<_>>(),
             &common_vars
                 .iter()
                 .map(|x| var_names.get_index(x))

--- a/anndata/src/container/base.rs
+++ b/anndata/src/container/base.rs
@@ -71,12 +71,12 @@ impl<T> Slot<T> {
 
     /// Insert data to the slot, and return the old data.
     pub fn insert(&self, data: T) -> Option<T> {
-        std::mem::replace(self.0.lock().deref_mut(), Some(data))
+        self.0.lock().deref_mut().replace(data)
     }
 
     /// Extract the data from the slot. The slot becomes empty after this operation.
     pub fn extract(&self) -> Option<T> {
-        std::mem::replace(self.0.lock().deref_mut(), None)
+        self.0.lock().deref_mut().take()
     }
 
     /// Remove the data from the slot.
@@ -202,7 +202,7 @@ impl<B: Backend> InnerDataFrameElem<B> {
             None => {
                 let df = DataFrame::read(&self.container)?;
                 self.element = Some(df);
-                Ok(&self.element.as_ref().unwrap())
+                Ok(self.element.as_ref().unwrap())
             }
         }
     }
@@ -337,11 +337,11 @@ impl<B: Backend> InnerElem<B> {
 
     pub fn data(&mut self) -> Result<Data> {
         match self.element.as_ref() {
-            Some(data) => Ok(data.clone().try_into()?),
+            Some(data) => Ok(data.clone()),
             None => {
                 let data = Data::read(&self.container)?;
                 if self.cache_enabled {
-                    self.element = Some(data.clone().into());
+                    self.element = Some(data.clone());
                 }
                 Ok(data)
             }
@@ -353,7 +353,7 @@ impl<B: Backend> InnerElem<B> {
         let _ = std::mem::replace(&mut self.container, new);
         self.dtype = data.data_type();
         if self.element.is_some() {
-            self.element = Some(data.into());
+            self.element = Some(data);
         }
         Ok(())
     }
@@ -429,11 +429,11 @@ impl<B: Backend> InnerArrayElem<B> {
 
     pub fn data(&mut self) -> Result<ArrayData> {
         match self.element.as_ref() {
-            Some(data) => Ok(data.clone().try_into()?),
+            Some(data) => Ok(data.clone()),
             None => {
                 let data = ArrayData::read(&self.container)?;
                 if self.cache_enabled {
-                    self.element = Some(data.clone().into());
+                    self.element = Some(data.clone());
                 }
                 Ok(data)
             }
@@ -446,7 +446,7 @@ impl<B: Backend> InnerArrayElem<B> {
         self.dtype = data.data_type();
         self.shape = data.shape();
         if self.element.is_some() {
-            self.element = Some(data.into());
+            self.element = Some(data);
         }
         Ok(())
     }
@@ -459,7 +459,7 @@ impl<B: Backend> InnerArrayElem<B> {
             self.data()
         } else {
             match self.element.as_ref() {
-                Some(data) => Ok(data.select(selection).try_into()?),
+                Some(data) => Ok(data.select(selection)),
                 None => ArrayData::read_select(&self.container, selection),
             }
         }
@@ -632,7 +632,7 @@ impl<B: Backend> StackedDataFrame<B> {
                     .collect::<Vec<_>>()
             })
             .reduce(|mut acc, next| {
-                acc.iter_mut().zip(next.into_iter()).for_each(|(a, b)| {
+                acc.iter_mut().zip(next).for_each(|(a, b)| {
                     a.append(&b).unwrap();
                 });
                 acc
@@ -646,7 +646,7 @@ impl<B: Backend> StackedDataFrame<B> {
     where
         S: AsRef<SelectInfoElem>,
     {
-        let (indices, mapping) = self.index.split_select(selection.as_ref()[0].as_ref());
+        let (indices, mapping) = self.index.split_select(selection[0].as_ref());
         let dfs = self
             .elems
             .iter()
@@ -654,7 +654,7 @@ impl<B: Backend> StackedDataFrame<B> {
             .flat_map(|(i, el)| {
                 indices.get(&i).and_then(|idx| {
                     let select: SmallVec<[_; 3]> = std::iter::once(idx)
-                        .chain(selection.as_ref()[1..].iter().map(|x| x.as_ref()))
+                        .chain(selection[1..].iter().map(|x| x.as_ref()))
                         .collect();
                     el.lock()
                         .as_mut()
@@ -673,7 +673,10 @@ impl<B: Backend> StackedDataFrame<B> {
         .collect()?;
         if let Some(m) = mapping {
             let select: SmallVec<[SelectInfoElem; 3]> = std::iter::once(m.into())
-                .chain(std::iter::repeat((..).into()).take(selection.as_ref().len() - 1))
+                .chain(std::iter::repeat_n(
+                    (..).into(),
+                    selection.as_ref().len() - 1,
+                ))
                 .collect();
             Ok(Selectable::select(&df, select.as_slice()))
         } else {
@@ -699,7 +702,7 @@ pub struct InnerStackedArrayElem<B: Backend> {
 
 impl<B: Backend> std::fmt::Display for InnerStackedArrayElem<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.elems.len() == 0 {
+        if self.elems.is_empty() {
             write!(f, "empty stacked elements")
         } else {
             write!(
@@ -786,7 +789,7 @@ impl<B: Backend> InnerStackedArrayElem<B> {
         let data = if self.is_none() {
             None
         } else {
-            let (indices, mapping) = self.index.split_select(selection.as_ref()[0].as_ref());
+            let (indices, mapping) = self.index.split_select(selection[0].as_ref());
             let array: ArrayData = self
                 .elems
                 .iter()
@@ -794,13 +797,13 @@ impl<B: Backend> InnerStackedArrayElem<B> {
                 .map(|(i, el)| {
                     if let Some(idx) = indices.get(&i) {
                         let select: SmallVec<[_; 3]> = std::iter::once(idx)
-                            .chain(selection.as_ref()[1..].iter().map(|x| x.as_ref()))
+                            .chain(selection[1..].iter().map(|x| x.as_ref()))
                             .collect();
                         el.inner().select(select.as_slice())
                     } else {
                         let idx = SelectInfoElem::empty();
                         let select: SmallVec<[_; 3]> = std::iter::once(&idx)
-                            .chain(selection.as_ref()[1..].iter().map(|x| x.as_ref()))
+                            .chain(selection[1..].iter().map(|x| x.as_ref()))
                             .collect();
                         el.inner().select(select.as_slice())
                     }
@@ -829,7 +832,7 @@ impl<B: Backend> InnerStackedArrayElem<B> {
         let data = if self.is_none() {
             None
         } else {
-            let (indices, mapping) = self.index.split_select(selection.as_ref()[0].as_ref());
+            let (indices, mapping) = self.index.split_select(selection[0].as_ref());
             let array: ArrayData = self
                 .elems
                 .par_iter()
@@ -837,7 +840,7 @@ impl<B: Backend> InnerStackedArrayElem<B> {
                 .flat_map(|(i, el)| {
                     indices.get(&i).map(|idx| {
                         let select: SmallVec<[_; 3]> = std::iter::once(idx)
-                            .chain(selection.as_ref()[1..].iter().map(|x| x.as_ref()))
+                            .chain(selection[1..].iter().map(|x| x.as_ref()))
                             .collect();
                         el.inner().select(select.as_slice())
                     })
@@ -929,7 +932,7 @@ impl<B: Backend> StackedArrayElem<B> {
             "all elements must have the same shape except for the first axis"
         );
         let index: VecVecIndex = shapes.iter().flatten().map(|x| x.as_ref()[0]).collect();
-        let shape = shapes.get(0).and_then(|x| {
+        let shape = shapes.first().and_then(|x| {
             x.as_ref().map(|s| {
                 let mut ss = s.clone();
                 ss[0] = index.len();
@@ -947,7 +950,7 @@ impl<B: Backend> StackedArrayElem<B> {
     where
         D: TryFrom<ArrayData>,
     {
-        StackedChunkedArrayElem::new(self.elems.iter().map(|x| x.clone()), chunk_size)
+        StackedChunkedArrayElem::new(self.elems.iter().cloned(), chunk_size)
     }
 }
 

--- a/anndata/src/container/base.rs
+++ b/anndata/src/container/base.rs
@@ -283,7 +283,7 @@ impl<B: Backend> TryFrom<DataContainer<B>> for DataFrameElem<B> {
                 };
                 Ok(Slot::new(df))
             }
-            ty => bail!("Expecting a dataframe but found: '{}'", ty),
+            ty => bail!("Expecting a dataframe but found: '{ty}'"),
         }
     }
 }

--- a/anndata/src/container/collection.rs
+++ b/anndata/src/container/collection.rs
@@ -298,7 +298,10 @@ impl<B: Backend> InnerAxisArrays<B> {
         if let Some(dim) = &self.dim1 {
             dim.get()
         } else {
-            self.data.values().next().map_or(0, |x| x.inner().shape()[0])
+            self.data
+                .values()
+                .next()
+                .map_or(0, |x| x.inner().shape()[0])
         }
     }
 
@@ -351,9 +354,8 @@ impl<B: Backend> InnerAxisArrays<B> {
         if let Some(elem) = self.get(key) {
             elem.clear()?;
         }
-        let elem = ArrayChunk::write_by_chunk(data, &self.container, key).with_context(|| {
-            format!("failed to write data to AxisArrays with key: '{}'", key)
-        })?;
+        let elem = ArrayChunk::write_by_chunk(data, &self.container, key)
+            .with_context(|| format!("failed to write data to AxisArrays with key: '{}'", key))?;
         let elem = ArrayElem::try_from(elem)?;
 
         let shape = { elem.inner().shape().clone() };
@@ -369,7 +371,8 @@ impl<B: Backend> InnerAxisArrays<B> {
             }
             Axis::RowColumn => {
                 if let Err(e) = self
-                    .dim1().try_set(shape[0])
+                    .dim1()
+                    .try_set(shape[0])
                     .and(self.dim2.as_ref().unwrap().try_set(shape[1]))
                 {
                     elem.clear()?;
@@ -484,15 +487,20 @@ impl<B: Backend> AxisArrays<B> {
         self.is_none() || self.inner().data.is_empty()
     }
 
-    pub fn new(group: B::Group, axis: Axis, dim1: Option<&Dim>, dim2: Option<&Dim>) -> Result<Self> {
+    pub fn new(
+        group: B::Group,
+        axis: Axis,
+        dim1: Option<&Dim>,
+        dim2: Option<&Dim>,
+    ) -> Result<Self> {
         let data: HashMap<_, _> = iter_containers::<B>(&group)
             .map(|(k, v)| (k, ArrayElem::try_from(v).unwrap()))
             .collect();
 
         // Get shapes of arrays
         let shapes = data
-            .iter()
-            .map(|(_, v)| v.inner().shape().clone())
+            .values()
+            .map(|v| v.inner().shape().clone())
             .collect::<Vec<_>>();
 
         // Check if shapes of arrays conform to axis
@@ -513,14 +521,14 @@ impl<B: Backend> AxisArrays<B> {
             );
         }
 
-        if let Some(s) = shapes.get(0) {
+        if let Some(s) = shapes.first() {
             if let Some(d) = dim1 {
                 d.try_set(s[0])?;
             }
-            if let Axis::RowColumn = axis {
-                if let Some(d) = dim2 {
-                    d.try_set(s[1])?;
-                }
+            if let Axis::RowColumn = axis
+                && let Some(d) = dim2
+            {
+                d.try_set(s[1])?;
             }
         }
 
@@ -635,7 +643,7 @@ impl<B: Backend> StackedAxisArrays<B> {
             );
         }
         Ok(Self {
-            axis: axis,
+            axis,
             data: Arc::new(data),
         })
     }

--- a/anndata/src/container/collection.rs
+++ b/anndata/src/container/collection.rs
@@ -49,7 +49,7 @@ impl<B: Backend> std::fmt::Display for InnerElemCollection<B> {
             .map(|x| x.to_string())
             .collect::<Vec<_>>()
             .join(", ");
-        write!(f, "Dict with keys: {}", keys)
+        write!(f, "Dict with keys: {keys}")
     }
 }
 
@@ -288,7 +288,7 @@ impl<B: Backend> std::fmt::Display for InnerAxisArrays<B> {
             .map(|x| x.to_string())
             .collect::<Vec<_>>()
             .join(", ");
-        write!(f, "AxisArrays ({}) with keys: {}", ty, keys)
+        write!(f, "AxisArrays ({ty}) with keys: {keys}")
     }
 }
 
@@ -328,8 +328,7 @@ impl<B: Backend> InnerAxisArrays<B> {
             Axis::Pairwise => {
                 ensure!(
                     shape[0] == shape[1],
-                    "expecting a square array, but receive a {:?} array",
-                    shape
+                    "expecting a square array, but receive a {shape:?} array"
                 );
                 self.dim1().try_set(shape[0])?;
             }
@@ -355,7 +354,7 @@ impl<B: Backend> InnerAxisArrays<B> {
             elem.clear()?;
         }
         let elem = ArrayChunk::write_by_chunk(data, &self.container, key)
-            .with_context(|| format!("failed to write data to AxisArrays with key: '{}'", key))?;
+            .with_context(|| format!("failed to write data to AxisArrays with key: '{key}'"))?;
         let elem = ArrayElem::try_from(elem)?;
 
         let shape = { elem.inner().shape().clone() };
@@ -385,7 +384,7 @@ impl<B: Backend> InnerAxisArrays<B> {
             Axis::Pairwise => {
                 if shape[0] != shape[1] {
                     elem.clear()?;
-                    bail!("expecting a square array, but receive a {:?} array", shape)
+                    bail!("expecting a square array, but receive a {shape:?} array")
                 } else if let Err(e) = self.dim1().try_set(shape[0]) {
                     elem.clear()?;
                     bail!(e)
@@ -592,7 +591,7 @@ impl<B: Backend> std::fmt::Display for StackedAxisArrays<B> {
             .map(|x| x.to_string())
             .collect::<Vec<_>>()
             .join(", ");
-        write!(f, "Stacked AxisArrays ({}) with keys: {}", ty, keys)
+        write!(f, "Stacked AxisArrays ({ty}) with keys: {keys}")
     }
 }
 

--- a/anndata/src/container/mod.rs
+++ b/anndata/src/container/mod.rs
@@ -2,7 +2,7 @@ pub(crate) mod base;
 pub(crate) mod collection;
 
 pub use base::{
-    InnerDataFrameElem, DataFrameElem, Elem, Inner, ArrayElem, Slot,
-    StackedDataFrame, StackedArrayElem, ChunkedArrayElem, StackedChunkedArrayElem,
+    ArrayElem, ChunkedArrayElem, DataFrameElem, Elem, Inner, InnerDataFrameElem, Slot,
+    StackedArrayElem, StackedChunkedArrayElem, StackedDataFrame,
 };
-pub use collection::{Dim, Axis, AxisArrays, ElemCollection, StackedAxisArrays};
+pub use collection::{Axis, AxisArrays, Dim, ElemCollection, StackedAxisArrays};

--- a/anndata/src/data.rs
+++ b/anndata/src/data.rs
@@ -9,7 +9,7 @@ pub use mapping::*;
 
 use crate::backend::{Backend, DataContainer, DataType, GroupOp};
 
-use anyhow::{bail, Ok, Result};
+use anyhow::{Ok, Result, bail};
 use nalgebra_sparse::csc::CscMatrix;
 use nalgebra_sparse::csr::CsrMatrix;
 use ndarray::{Array, RemoveAxis};
@@ -140,9 +140,9 @@ impl TryFrom<Data> for Mapping {
     }
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// Data traits
-////////////////////////////////////////////////////////////////////////////////
+//-----------------------------------------------------------------------------
+// Data traits
+//-----------------------------------------------------------------------------
 
 impl Readable for Data {
     fn read<B: Backend>(container: &DataContainer<B>) -> Result<Self> {

--- a/anndata/src/data/array.rs
+++ b/anndata/src/data/array.rs
@@ -206,7 +206,7 @@ impl Readable for ArrayData {
             DataType::CsrMatrix(_) => read_csr(container),
             DataType::CscMatrix(_) => DynCscMatrix::read(container).map(ArrayData::CscMatrix),
             DataType::DataFrame => DataFrame::read(container).map(ArrayData::DataFrame),
-            ty => bail!("Cannot read type '{:?}' as matrix data", ty),
+            ty => bail!("Cannot read type '{ty:?}' as matrix data"),
         }
     }
 }
@@ -365,7 +365,7 @@ impl ReadableArray for ArrayData {
             DataType::CsrMatrix(_) => DynCsrMatrix::get_shape(container),
             DataType::CscMatrix(_) => DynCscMatrix::get_shape(container),
             DataType::DataFrame => DataFrame::get_shape(container),
-            ty => bail!("Cannot read shape information from type '{}'", ty),
+            ty => bail!("Cannot read shape information from type '{ty}'"),
         }
     }
 
@@ -385,7 +385,7 @@ impl ReadableArray for ArrayData {
             DataType::DataFrame => {
                 DataFrame::read_select(container, info).map(ArrayData::DataFrame)
             }
-            ty => bail!("Cannot read type '{:?}' as matrix data", ty),
+            ty => bail!("Cannot read type '{ty:?}' as matrix data"),
         }
     }
 }

--- a/anndata/src/data/array.rs
+++ b/anndata/src/data/array.rs
@@ -5,7 +5,7 @@ pub mod slice;
 mod sparse;
 pub mod utils;
 
-pub use chunks::{MatrixBuilder, ArrayChunk};
+pub use chunks::{ArrayChunk, MatrixBuilder};
 pub use dataframe::DataFrameIndex;
 pub use dense::{ArrayConvert, CategoricalArray, DynArray, DynCowArray, DynScalar};
 pub use slice::{SelectInfo, SelectInfoBounds, SelectInfoElem, SelectInfoElemBounds, Shape};
@@ -13,10 +13,10 @@ pub use sparse::{CsrNonCanonical, DynCscMatrix, DynCsrMatrix, DynCsrNonCanonical
 
 use crate::backend::*;
 use crate::data::utils::from_csr_data;
-use crate::data::{data_traits::*, DataType};
+use crate::data::{DataType, data_traits::*};
 
 use ::ndarray::{Array, ArrayD, Ix1, RemoveAxis};
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use nalgebra_sparse::csc::CscMatrix;
 use nalgebra_sparse::csr::CsrMatrix;
 use polars::prelude::DataFrame;
@@ -440,7 +440,7 @@ fn read_csr<B: Backend>(container: &DataContainer<B>) -> Result<ArrayData> {
     }
 }
 
-fn read_csr_select<B: Backend, S>(container: &DataContainer<B>, info: &[S]) -> Result<ArrayData>
+fn read_csr_select<B, S>(container: &DataContainer<B>, info: &[S]) -> Result<ArrayData>
 where
     B: Backend,
     S: AsRef<SelectInfoElem>,

--- a/anndata/src/data/array/chunks.rs
+++ b/anndata/src/data/array/chunks.rs
@@ -3,11 +3,11 @@ use crate::data::{ArrayData, array::DynArray, array::utils::ExtendableDataset};
 use crate::{ArrayElem, Selectable};
 
 use super::{CsrNonCanonical, DynCscMatrix, DynCsrMatrix, DynCsrNonCanonical};
+use crate::backend::get_default_write_config;
 use anyhow::{Context, Result, bail};
 use nalgebra_sparse::na::Scalar;
 use nalgebra_sparse::{CscMatrix, CsrMatrix};
 use ndarray::{Array, Array1, ArrayD, ArrayView1, RemoveAxis};
-use crate::backend::get_default_write_config;
 
 pub enum MatrixBuilder<B: Backend> {
     CsrMatrix(CsrMatrixBuilder<B>),

--- a/anndata/src/data/array/dataframe.rs
+++ b/anndata/src/data/array/dataframe.rs
@@ -135,12 +135,15 @@ impl Selectable for DataFrame {
                 .into_iter()
                 .map(|i| columns[i].as_str()),
         )
-        .expect(&format!(
-            "Failed to select columns: {:?}",
-            select.as_ref()[1]
-        ))
+        .unwrap_or_else(|_| panic!("Failed to select columns: {:?}", select.as_ref()[1]))
         .take(&ChunkedArray::from_vec("idx".into(), ridx))
-        .expect(&format!("Failed to select rows: {:?}, shape: {:?}", select.as_ref()[0], self.shape()))
+        .unwrap_or_else(|_| {
+            panic!(
+                "Failed to select rows: {:?}, shape: {:?}",
+                select.as_ref()[0],
+                self.shape()
+            )
+        })
     }
 }
 
@@ -170,27 +173,26 @@ impl ReadableArray for DataFrame {
         S: AsRef<SelectInfoElem>,
     {
         let columns: Vec<String> = container.get_attr("column-order")?;
-        let columns: Result<Vec<Column>> =
-            SelectInfoElemBounds::new(&info.as_ref()[1], columns.len())
-                .iter()
-                .map(|i| {
-                    let name = &columns[i];
-                    let series = container
-                        .as_group()?
-                        .open_dataset(name)
-                        .map(DataContainer::Dataset)
-                        .and_then(|x| read_series::<B>(&x))
-                        .with_context(|| format!("Failed to read series: {}", name))?;
+        let columns: Result<Vec<Column>> = SelectInfoElemBounds::new(&info[1], columns.len())
+            .iter()
+            .map(|i| {
+                let name = &columns[i];
+                let series = container
+                    .as_group()?
+                    .open_dataset(name)
+                    .map(DataContainer::Dataset)
+                    .and_then(|x| read_series::<B>(&x))
+                    .with_context(|| format!("Failed to read series: {}", name))?;
 
-                    let indices: Vec<u32> = SelectInfoElemBounds::new(&info[0], series.len())
-                        .iter()
-                        .map(|x| x.try_into().unwrap())
-                        .collect();
-                    let mut series = series.take_slice(indices.as_slice())?;
-                    series.rename(name.into());
-                    Ok(series.into())
-                })
-                .collect();
+                let indices: Vec<u32> = SelectInfoElemBounds::new(&info[0], series.len())
+                    .iter()
+                    .map(|x| x.try_into().unwrap())
+                    .collect();
+                let mut series = series.take_slice(indices.as_slice())?;
+                series.rename(name.into());
+                Ok(series.into())
+            })
+            .collect();
         Ok(DataFrame::new_infer_height(columns?)?)
     }
 }
@@ -352,9 +354,9 @@ where
     }
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// Helper functions
-////////////////////////////////////////////////////////////////////////////////
+//-----------------------------------------------------------------------------
+// Helper functions
+//-----------------------------------------------------------------------------
 
 fn write_column<B: Backend, G: GroupOp<B>>(
     series: &Column,
@@ -373,13 +375,13 @@ fn write_column<B: Backend, G: GroupOp<B>>(
         DataType::Float32 => series
             .f32()?
             .into_iter()
-            .map(|x| x.unwrap_or(std::f32::NAN))
+            .map(|x| x.unwrap_or(f32::NAN))
             .collect::<Array1<f32>>()
             .write(location, name),
         DataType::Float64 => series
             .f64()?
             .into_iter()
-            .map(|x| x.unwrap_or(std::f64::NAN))
+            .map(|x| x.unwrap_or(f64::NAN))
             .collect::<Array1<f64>>()
             .write(location, name),
         DataType::Boolean => write_series_helper(series.bool()?, location, name),

--- a/anndata/src/data/array/dataframe.rs
+++ b/anndata/src/data/array/dataframe.rs
@@ -103,7 +103,7 @@ impl Readable for DataFrame {
                     let name = name.as_str();
                     let series_container = DataContainer::<B>::open(container.as_group()?, name)?;
                     let mut series = read_series::<B>(&series_container)
-                        .with_context(|| format!("Failed to read series: {}", name))?;
+                        .with_context(|| format!("Failed to read series: {name}"))?;
                     series.rename(name.into());
                     Ok(series.into())
                 })
@@ -182,7 +182,7 @@ impl ReadableArray for DataFrame {
                     .open_dataset(name)
                     .map(DataContainer::Dataset)
                     .and_then(|x| read_series::<B>(&x))
-                    .with_context(|| format!("Failed to read series: {}", name))?;
+                    .with_context(|| format!("Failed to read series: {name}"))?;
 
                 let indices: Vec<u32> = SelectInfoElemBounds::new(&info[0], series.len())
                     .iter()
@@ -275,7 +275,7 @@ impl DataFrameIndex {
                 let end: u64 = dataset.get_attr("end")?;
                 Ok((start as usize..end as usize).into())
             }
-            x => bail!("Unknown index type: {}", x),
+            x => bail!("Unknown index type: {x}"),
         }
     }
 
@@ -405,7 +405,7 @@ fn write_column<B: Backend, G: GroupOp<B>>(
             .iter_str()
             .collect::<CategoricalArray>()
             .write(location, name),
-        other => bail!("Unsupported series data type: {:?}", other),
+        other => bail!("Unsupported series data type: {other:?}"),
     }
 }
 
@@ -422,7 +422,7 @@ fn read_series<B: Backend>(container: &DataContainer<B>) -> Result<Series> {
         }
         crate::backend::DataType::Array(_) => Ok(DynArray::read(container)?.into()),
         crate::backend::DataType::NullableArray => read_nullable(container),
-        _ => bail!("Unsupported data type: {:?}", ty),
+        _ => bail!("Unsupported data type: {ty:?}"),
     }
 }
 

--- a/anndata/src/data/array/dense.rs
+++ b/anndata/src/data/array/dense.rs
@@ -11,12 +11,12 @@ use crate::{
     },
 };
 
+use crate::backend::get_default_write_config;
 use anyhow::{Result, anyhow};
 use ndarray::{Array, Array1, ArrayD, ArrayView, Axis, Dimension, RemoveAxis, SliceInfoElem};
 use polars::series::Series;
 use std::collections::HashMap;
 use std::ops::Index;
-use crate::backend::get_default_write_config;
 
 impl<'a, T: BackendData, D> Element for ArrayView<'a, T, D> {
     fn metadata(&self) -> MetaData {
@@ -83,7 +83,7 @@ impl<T, D: Dimension> HasShape for Array<T, D> {
 
 impl<T: BackendData, D: Dimension> Indexable for Array<T, D> {
     fn get(&self, index: &[usize]) -> Option<DynScalar> {
-        self.view().into_dyn().get(index).map(|x| x.into_dyn())
+        self.view().into_dyn().get(index).map(|x| x.as_dyn())
     }
 }
 
@@ -95,9 +95,9 @@ impl<T: Clone, D: Dimension> Selectable for Array<T, D> {
         let arr = self.view().into_dyn();
         let slices = info
             .as_ref()
-            .into_iter()
+            .iter()
             .map(|x| match x.as_ref() {
-                SelectInfoElem::Slice(slice) => Some(SliceInfoElem::from(slice.clone())),
+                SelectInfoElem::Slice(slice) => Some(SliceInfoElem::from(*slice)),
                 _ => None,
             })
             .collect::<Option<Vec<_>>>();
@@ -107,16 +107,13 @@ impl<T: Clone, D: Dimension> Selectable for Array<T, D> {
             let shape = self.shape();
             let select: Vec<_> = info
                 .as_ref()
-                .into_iter()
+                .iter()
                 .zip(shape)
                 .map(|(x, n)| SelectInfoElemBounds::new(x.as_ref(), *n))
                 .collect();
             let new_shape = select.iter().map(|x| x.len()).collect::<Vec<_>>();
             ArrayD::from_shape_fn(new_shape, |idx| {
-                let new_idx: Vec<_> = (0..idx.ndim())
-                    .into_iter()
-                    .map(|i| select[i].index(idx[i]))
-                    .collect();
+                let new_idx: Vec<_> = (0..idx.ndim()).map(|i| select[i].index(idx[i])).collect();
                 arr.index(new_idx.as_slice()).clone()
             })
         }
@@ -137,13 +134,13 @@ impl<T: Clone, D: RemoveAxis> Stackable for Array<T, D> {
 
 impl<T: BackendData, D: Dimension> Readable for Array<T, D> {
     fn read<B: Backend>(container: &DataContainer<B>) -> Result<Self> {
-        Ok(container.as_dataset()?.read_array::<T, D>()?)
+        container.as_dataset()?.read_array::<T, D>()
     }
 }
 
 impl<T: BackendData, D: Dimension> ReadableArray for Array<T, D> {
     fn get_shape<B: Backend>(container: &DataContainer<B>) -> Result<Shape> {
-        Ok(container.as_dataset()?.shape().into())
+        Ok(container.as_dataset()?.shape())
     }
 
     fn read_select<B, S>(container: &DataContainer<B>, info: &[S]) -> Result<Self>
@@ -176,10 +173,13 @@ impl TryInto<Series> for CategoricalArray {
         if self.codes.shape().len() != 1 {
             return Err(anyhow!("Can only convert 1D CategoricalArray to Series"));
         }
-        let series = self.codes.into_iter().map(|x|
-            x.and_then(|idx| 
-                ndarray::ArrayRef::get(&self.categories, idx as usize).cloned())
-        ).collect();
+        let series = self
+            .codes
+            .into_iter()
+            .map(|x| {
+                x.and_then(|idx| ndarray::ArrayRef::get(&self.categories, idx as usize).cloned())
+            })
+            .collect();
         Ok(series)
     }
 }
@@ -287,7 +287,7 @@ impl ReadableArray for CategoricalArray {
     fn get_shape<B: Backend>(container: &DataContainer<B>) -> Result<Shape> {
         let group = container.as_group()?;
         let codes = group.open_dataset("codes")?.shape();
-        Ok(codes.into())
+        Ok(codes)
     }
 
     fn read_select<B, S>(container: &DataContainer<B>, info: &[S]) -> Result<Self>
@@ -303,14 +303,22 @@ impl ReadableArray for CategoricalArray {
     }
 }
 
-impl<T: BackendData + num::ToPrimitive + Clone, D: Dimension + RemoveAxis> ArrayArithmetic for Array<T, D> {
+impl<T: BackendData + num::ToPrimitive + Clone, D: Dimension + RemoveAxis> ArrayArithmetic
+    for Array<T, D>
+{
     fn sum(&self) -> f64 {
-        self.iter().map(|x| <f64 as NumCast>::from(x.clone()).unwrap()).sum()
+        self.iter()
+            .map(|x| <f64 as NumCast>::from(x.clone()).unwrap())
+            .sum()
     }
 
     fn sum_axis(&self, axis: usize) -> Result<ArrayD<f64>> {
         if axis >= self.ndim() {
-            anyhow::bail!("axis {} out of bounds for array of dimension {}", axis, self.ndim());
+            anyhow::bail!(
+                "axis {} out of bounds for array of dimension {}",
+                axis,
+                self.ndim()
+            );
         }
         let arr = self.map(|x| <f64 as NumCast>::from(x.clone()).unwrap());
         Ok(Array::sum_axis(&arr, axis)?.into_dyn())

--- a/anndata/src/data/array/dense/dynamic.rs
+++ b/anndata/src/data/array/dense/dynamic.rs
@@ -682,7 +682,7 @@ impl<D: Dimension> ArrayConvert<Array<f32, D>> for DynArray {
             DynArray::U8(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::U16(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::Bool(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
-            _ => bail!("Cannot convert {:?} to f32 Array", self),
+            _ => bail!("Cannot convert {self:?} to f32 Array"),
         }
     }
 }
@@ -705,7 +705,7 @@ impl<D: Dimension> ArrayConvert<Array<f64, D>> for DynArray {
                 .into_dimensionality()?),
             DynArray::F32(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::Bool(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
-            _ => bail!("Cannot convert {:?} to f64 Array", self),
+            _ => bail!("Cannot convert {self:?} to f64 Array"),
         }
     }
 }
@@ -714,7 +714,7 @@ impl<D: Dimension> ArrayConvert<Array<bool, D>> for DynArray {
     fn try_convert(self) -> Result<Array<bool, D>> {
         match self {
             DynArray::Bool(data) => Ok(data.into_dimensionality()?),
-            _ => bail!("Cannot convert {:?} to bool Array", self),
+            _ => bail!("Cannot convert {self:?} to bool Array"),
         }
     }
 }

--- a/anndata/src/data/array/dense/dynamic.rs
+++ b/anndata/src/data/array/dense/dynamic.rs
@@ -6,8 +6,8 @@ use crate::{
     },
 };
 
-use anyhow::{bail, ensure, Result};
-use ndarray::{arr0, Array, ArrayD, ArrayView, CowArray, Dimension, IxDyn};
+use anyhow::{Result, bail, ensure};
+use ndarray::{Array, ArrayD, ArrayView, CowArray, Dimension, IxDyn, arr0};
 use num::NumCast;
 use paste::paste;
 use polars::series::Series;
@@ -161,6 +161,11 @@ impl DynArray {
         crate::macros::dyn_map_fun!(self, DynArray, len)
     }
 
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        crate::macros::dyn_map_fun!(self, DynArray, is_empty)
+    }
+
     impl_dynarray_into_array!(
         I8, i8, I16, i16, I32, i32, I64, i64, U8, u8, U16, u16, U32, u32, U64, u64, F32, f32, F64,
         f64, Bool, bool, String, String
@@ -194,9 +199,9 @@ impl_dynarray_traits!(
     bool, Bool, String, String
 );
 
-impl Into<Series> for DynArray {
-    fn into(self) -> Series {
-        match self {
+impl From<DynArray> for Series {
+    fn from(val: DynArray) -> Self {
+        match val {
             DynArray::I8(x) => x.iter().collect(),
             DynArray::I16(x) => x.iter().collect(),
             DynArray::I32(x) => x.iter().collect(),
@@ -319,7 +324,7 @@ impl Stackable for DynArray {
 impl WritableArray for DynArray {}
 impl ReadableArray for DynArray {
     fn get_shape<B: Backend>(container: &DataContainer<B>) -> Result<Shape> {
-        Ok(container.as_dataset()?.shape().into())
+        Ok(container.as_dataset()?.shape())
     }
 
     fn read_select<B, S>(container: &DataContainer<B>, info: &[S]) -> Result<Self>
@@ -371,6 +376,11 @@ impl DynCowArray<'_> {
 
     pub fn len(&self) -> usize {
         crate::macros::dyn_map_fun!(self, DynCowArray, len)
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        crate::macros::dyn_map_fun!(self, DynCowArray, is_empty)
     }
 }
 
@@ -438,13 +448,25 @@ impl<D: Dimension> ArrayConvert<Array<i8, D>> for DynArray {
     fn try_convert(self) -> Result<Array<i8, D>> {
         match self {
             DynArray::I8(data) => Ok(data.into_dimensionality()?),
-            DynArray::I16(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I32(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
+            DynArray::I16(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::I32(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::I64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
             DynArray::U8(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::U16(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::U32(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::U64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
+            DynArray::U16(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::U32(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::U64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
             DynArray::Bool(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             _ => bail!("Cannot convert to i8 Array"),
         }
@@ -456,12 +478,22 @@ impl<D: Dimension> ArrayConvert<Array<i16, D>> for DynArray {
         match self {
             DynArray::I16(data) => Ok(data.into_dimensionality()?),
             DynArray::I8(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
-            DynArray::I32(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
+            DynArray::I32(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::I64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
             DynArray::U8(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
-            DynArray::U16(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::U32(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::U64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
+            DynArray::U16(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::U32(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::U64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
             DynArray::Bool(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             _ => bail!("Cannot convert to i16 Array"),
         }
@@ -474,11 +506,17 @@ impl<D: Dimension> ArrayConvert<Array<i32, D>> for DynArray {
             DynArray::I32(data) => Ok(data.into_dimensionality()?),
             DynArray::I8(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::I16(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
-            DynArray::I64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
+            DynArray::I64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
             DynArray::U8(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::U16(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
-            DynArray::U32(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::U64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
+            DynArray::U32(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::U64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
             DynArray::Bool(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             _ => bail!("Cannot convert to i32 Array"),
         }
@@ -495,7 +533,9 @@ impl<D: Dimension> ArrayConvert<Array<i64, D>> for DynArray {
             DynArray::U8(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::U16(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::U32(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
-            DynArray::U64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
+            DynArray::U64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
             DynArray::Bool(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             _ => bail!("Cannot convert to i64 Array"),
         }
@@ -507,12 +547,24 @@ impl<D: Dimension> ArrayConvert<Array<u8, D>> for DynArray {
         match self {
             DynArray::U8(data) => Ok(data.into_dimensionality()?),
             DynArray::I8(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I16(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I32(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::U16(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::U32(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::U64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
+            DynArray::I16(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::I32(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::I64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::U16(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::U32(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::U64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
             DynArray::Bool(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             _ => bail!("Cannot convert to u8 Array"),
         }
@@ -524,12 +576,22 @@ impl<D: Dimension> ArrayConvert<Array<u16, D>> for DynArray {
         match self {
             DynArray::U16(data) => Ok(data.into_dimensionality()?),
             DynArray::I8(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I16(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I32(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
+            DynArray::I16(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::I32(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::I64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
             DynArray::U8(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
-            DynArray::U32(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::U64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
+            DynArray::U32(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::U64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
             DynArray::Bool(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             _ => bail!("Cannot convert to u16 Array"),
         }
@@ -541,12 +603,20 @@ impl<D: Dimension> ArrayConvert<Array<u32, D>> for DynArray {
         match self {
             DynArray::U32(data) => Ok(data.into_dimensionality()?),
             DynArray::I8(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I16(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I32(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
+            DynArray::I16(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::I32(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::I64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
             DynArray::U8(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::U16(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
-            DynArray::U64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
+            DynArray::U64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
             DynArray::Bool(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             _ => bail!("Cannot convert to u32 Array"),
         }
@@ -558,9 +628,15 @@ impl<D: Dimension> ArrayConvert<Array<u64, D>> for DynArray {
         match self {
             DynArray::U64(data) => Ok(data.into_dimensionality()?),
             DynArray::I8(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I16(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I32(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
+            DynArray::I16(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::I32(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::I64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
             DynArray::U8(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::U16(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::U32(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
@@ -574,13 +650,23 @@ impl<D: Dimension> ArrayConvert<Array<usize, D>> for DynArray {
     fn try_convert(self) -> Result<Array<usize, D>> {
         match self {
             DynArray::I8(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I16(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I32(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::I64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
+            DynArray::I16(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::I32(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::I64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
             DynArray::U8(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::U16(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
-            DynArray::U32(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
-            DynArray::U64(data) => Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?),
+            DynArray::U32(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
+            DynArray::U64(data) => {
+                Ok(data.mapv(|x| x.try_into().unwrap()).into_dimensionality()?)
+            }
             DynArray::Bool(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             _ => bail!("Cannot convert to usize Array"),
         }
@@ -608,11 +694,15 @@ impl<D: Dimension> ArrayConvert<Array<f64, D>> for DynArray {
             DynArray::I8(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::I16(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::I32(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
-            DynArray::I64(data) => Ok(data.mapv(|x| NumCast::from(x).unwrap()).into_dimensionality()?),
+            DynArray::I64(data) => Ok(data
+                .mapv(|x| NumCast::from(x).unwrap())
+                .into_dimensionality()?),
             DynArray::U8(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::U16(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::U32(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
-            DynArray::U64(data) => Ok(data.mapv(|x| NumCast::from(x).unwrap()).into_dimensionality()?),
+            DynArray::U64(data) => Ok(data
+                .mapv(|x| NumCast::from(x).unwrap())
+                .into_dimensionality()?),
             DynArray::F32(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             DynArray::Bool(data) => Ok(data.mapv(|x| x.into()).into_dimensionality()?),
             _ => bail!("Cannot convert {:?} to f64 Array", self),

--- a/anndata/src/data/array/slice.rs
+++ b/anndata/src/data/array/slice.rs
@@ -290,14 +290,14 @@ impl SelectInfoElem {
         match self {
             SelectInfoElem::Index(index) => index.iter().try_for_each(|i| {
                 if *i >= bound {
-                    bail!("index out of bounds: {} >= {}", i, bound)
+                    bail!("index out of bounds: {i} >= {bound}")
                 } else {
                     Ok(())
                 }
             }),
             SelectInfoElem::Slice(slice) => slice.end.map_or(Ok(()), |end| {
                 if end > bound as isize {
-                    bail!("slice end out of bounds: {} >= {}", end, bound)
+                    bail!("slice end out of bounds: {end} >= {bound}")
                 } else {
                     Ok(())
                 }

--- a/anndata/src/data/array/slice.rs
+++ b/anndata/src/data/array/slice.rs
@@ -1,16 +1,16 @@
-use ndarray::{Array1, Array2, Slice, SliceInfo, SliceInfoElem, IxDyn};
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use itertools::Itertools;
+use ndarray::{Array1, Array2, IxDyn, Slice, SliceInfo, SliceInfoElem};
 use serde_json::Value;
-use std::ops::{RangeFull, Range, Index, IndexMut, RangeFrom, RangeTo};
 use smallvec::{SmallVec, smallvec};
+use std::ops::{Index, IndexMut, Range, RangeFrom, RangeFull, RangeTo};
 
 /// A structure that represents a shape, internally represented as a small vector.
-/// 
+///
 /// # Examples
 /// ```
 /// use anndata::data::Shape;
-/// 
+///
 /// let shape = Shape::from(vec![3, 4, 5]);
 /// assert_eq!(shape.ndim(), 3);
 /// ```
@@ -24,15 +24,19 @@ impl Shape {
     }
 }
 
-impl Into<Value> for Shape {
-    fn into(self) -> Value {
-        Value::Array(self.0.into_iter().map(|x| x.into()).collect())
+impl From<Shape> for Value {
+    fn from(val: Shape) -> Self {
+        Value::Array(val.0.into_iter().map(|x| x.into()).collect())
     }
 }
 
 impl std::fmt::Display for Shape {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0.as_slice().iter().map(|x| x.to_string()).join(" x "))
+        write!(
+            f,
+            "{}",
+            self.0.as_slice().iter().map(|x| x.to_string()).join(" x ")
+        )
     }
 }
 
@@ -120,20 +124,27 @@ impl FromIterator<Slice> for SelectInfo {
 
 impl<'a> FromIterator<&'a Slice> for SelectInfo {
     fn from_iter<T: IntoIterator<Item = &'a Slice>>(iter: T) -> Self {
-        Self(iter.into_iter().map(|x| SelectInfoElem::Slice(x.clone())).collect())
+        Self(
+            iter.into_iter()
+                .map(|x| SelectInfoElem::Slice(*x))
+                .collect(),
+        )
     }
 }
-
 
 impl TryInto<SliceInfo<Vec<SliceInfoElem>, IxDyn, IxDyn>> for SelectInfo {
     type Error = anyhow::Error;
 
     /// Attempts to convert `SelectInfo` into a `SliceInfo` object. Returns an error if conversion fails.
     fn try_into(self) -> Result<SliceInfo<Vec<SliceInfoElem>, IxDyn, IxDyn>> {
-        let elems: Result<Vec<_>> = self.0.into_iter().map(|e| match e {
-            SelectInfoElem::Slice(s) => Ok(SliceInfoElem::from(s)),
-            _ => bail!("Cannot convert SelectInfo to SliceInfo"),
-        }).collect();
+        let elems: Result<Vec<_>> = self
+            .0
+            .into_iter()
+            .map(|e| match e {
+                SelectInfoElem::Slice(s) => Ok(SliceInfoElem::from(s)),
+                _ => bail!("Cannot convert SelectInfo to SliceInfo"),
+            })
+            .collect();
         let slice = SliceInfo::try_from(elems?)?;
         Ok(slice)
     }
@@ -179,7 +190,7 @@ impl From<usize> for SelectInfoElem {
 
 impl From<&[usize]> for SelectInfoElem {
     fn from(x: &[usize]) -> Self {
-        Self::Index(x.into_iter().map(|x| *x).collect())
+        Self::Index(x.to_vec())
     }
 }
 
@@ -277,20 +288,20 @@ impl SelectInfoElem {
     /// Will panic if the index is out of bounds.
     pub fn bound_check(&self, bound: usize) -> Result<()> {
         match self {
-            SelectInfoElem::Index(index) => index.iter().try_for_each(|i|
+            SelectInfoElem::Index(index) => index.iter().try_for_each(|i| {
                 if *i >= bound {
                     bail!("index out of bounds: {} >= {}", i, bound)
                 } else {
                     Ok(())
                 }
-            ),
-            SelectInfoElem::Slice(slice) => {
-                slice.end.map_or(Ok(()), |end| if end > bound as isize {
+            }),
+            SelectInfoElem::Slice(slice) => slice.end.map_or(Ok(()), |end| {
+                if end > bound as isize {
                     bail!("slice end out of bounds: {} >= {}", end, bound)
                 } else {
                     Ok(())
-                })
-            }
+                }
+            }),
         }
     }
 
@@ -314,7 +325,12 @@ impl SelectInfoElem {
         })
     }
 
-    pub(crate) fn set_axis<'a>(&'a self, axis: usize, ndim: usize, fill: &'a Self) -> SmallVec<[&'a Self; 3]> {
+    pub(crate) fn set_axis<'a>(
+        &'a self,
+        axis: usize,
+        ndim: usize,
+        fill: &'a Self,
+    ) -> SmallVec<[&'a Self; 3]> {
         let mut slice = smallvec![fill; ndim];
         slice[axis] = self;
         slice
@@ -332,14 +348,14 @@ impl SelectInfoElem {
     }
 }
 
-/// `SelectInfoBounds` represents bounds-aware selection information. 
+/// `SelectInfoBounds` represents bounds-aware selection information.
 /// It includes an input shape and a list of selection elements with bound information for each axis.
-/// 
+///
 /// # Example
 /// ```
 /// use anndata::data::{Shape, SelectInfoElem, SelectInfoBounds};
 /// use ndarray::Slice;
-/// 
+///
 /// let shape = Shape::from(vec![5, 10]);
 /// let select = SelectInfoBounds::new(&[SelectInfoElem::Slice(Slice { start: 0, end: Some(5), step: 1 })], &shape);
 /// assert_eq!(select.in_shape(), shape);
@@ -357,20 +373,23 @@ impl<'a> AsRef<[SelectInfoElemBounds<'a>]> for SelectInfoBounds<'a> {
     }
 }
 
-impl<'a> TryInto<SliceInfo<Vec<SliceInfoElem>, IxDyn, IxDyn>> for SelectInfoBounds<'a>{
+impl<'a> TryInto<SliceInfo<Vec<SliceInfoElem>, IxDyn, IxDyn>> for SelectInfoBounds<'a> {
     type Error = anyhow::Error;
 
     /// Attempts to convert `SelectInfoBounds` into a `SliceInfo`, retaining the bounded selection elements.
     fn try_into(self) -> Result<SliceInfo<Vec<SliceInfoElem>, IxDyn, IxDyn>> {
-        let elems: Result<Vec<_>> = self.select.into_iter().map(|e| match e {
-            SelectInfoElemBounds::Slice(s) => Ok(s.into()),
-            _ => bail!("Cannot convert SelectInfo to SliceInfo"),
-        }).collect();
+        let elems: Result<Vec<_>> = self
+            .select
+            .into_iter()
+            .map(|e| match e {
+                SelectInfoElemBounds::Slice(s) => Ok(s.into()),
+                _ => bail!("Cannot convert SelectInfo to SliceInfo"),
+            })
+            .collect();
         let slice = SliceInfo::try_from(elems?)?;
         Ok(slice)
     }
 }
-
 
 impl<'a> SelectInfoBounds<'a> {
     /// Constructs a new `SelectInfoBounds` with a given selection and shape.
@@ -383,9 +402,12 @@ impl<'a> SelectInfoBounds<'a> {
         S: AsRef<[E]>,
         E: AsRef<SelectInfoElem> + 'a,
     {
-        let res: Vec<_> = select.as_ref().iter().zip(shape.as_ref()).map(|(sel, dim)|
-            SelectInfoElemBounds::new(sel.as_ref(), *dim)
-        ).collect();
+        let res: Vec<_> = select
+            .as_ref()
+            .iter()
+            .zip(shape.as_ref())
+            .map(|(sel, dim)| SelectInfoElemBounds::new(sel.as_ref(), *dim))
+            .collect();
         Self {
             input_shape: shape.clone(),
             select: res,
@@ -412,9 +434,9 @@ impl<'a> SelectInfoBounds<'a> {
         self.select.len()
     }
 
+    /*
     /// Convert to a new slice that contain only the unique indices. A mapping for
     /// getting back the original indices is also returned.
-    /*
     pub fn to_unique(&self) -> (Self, Self) {
         let out_shape = self.out_shape();
         let (unique, mapping): (Vec<_>, Vec<_>) = self.select.iter().zip(out_shape.as_ref())
@@ -430,11 +452,15 @@ impl<'a> SelectInfoBounds<'a> {
     */
 
     /// Attempts to convert the selection into indices. Fail if elements are all slices.
-    /// 
+    ///
     /// # Returns
     /// An optional `Array2` of indices if conversion is possible.
     pub fn try_into_indices(&self) -> Option<Array2<usize>> {
-        if self.select.iter().all(|e| matches!(e, SelectInfoElemBounds::Slice(_))) {
+        if self
+            .select
+            .iter()
+            .all(|e| matches!(e, SelectInfoElemBounds::Slice(_)))
+        {
             return None;
         }
 
@@ -445,33 +471,43 @@ impl<'a> SelectInfoBounds<'a> {
         let mut result: Array2<usize> = Array2::zeros((nrows, ncols));
 
         for c in 0..ncols {
-            let n_repeat = shape.as_ref()[(c+1)..].iter().product();
+            let n_repeat = shape.as_ref()[(c + 1)..].iter().product();
             match self.select[c] {
-                SelectInfoElemBounds::Index(ref x) => {
-                    let mut values = x.iter().flat_map(|x| std::iter::repeat(x).take(n_repeat)).cycle();
+                SelectInfoElemBounds::Index(x) => {
+                    let mut values = x
+                        .iter()
+                        .flat_map(|x| std::iter::repeat_n(x, n_repeat))
+                        .cycle();
                     for r in 0..nrows {
                         result[[r, c]] = *values.next().unwrap();
                     }
-                },
+                }
                 SelectInfoElemBounds::Slice(SliceBounds { start, end, step }) => {
                     if step > 0 {
-                        let mut values = (start..end).step_by(step as usize).flat_map(|x| std::iter::repeat(x).take(n_repeat)).cycle();
+                        let mut values = (start..end)
+                            .step_by(step as usize)
+                            .flat_map(|x| std::iter::repeat_n(x, n_repeat))
+                            .cycle();
                         for r in 0..nrows {
                             result[[r, c]] = values.next().unwrap();
                         }
                     } else {
-                        let mut values = (start..end).step_by(step.abs() as usize).rev().flat_map(|x| std::iter::repeat(x).take(n_repeat)).cycle();
+                        let mut values = (start..end)
+                            .step_by(step.unsigned_abs())
+                            .rev()
+                            .flat_map(|x| std::iter::repeat_n(x, n_repeat))
+                            .cycle();
                         for r in 0..nrows {
                             result[[r, c]] = values.next().unwrap();
                         }
                     }
-                },
+                }
             }
         }
         Some(result)
     }
 
-    pub fn iter(&self) -> impl ExactSizeIterator<Item=&SelectInfoElemBounds<'a>> + '_ {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &SelectInfoElemBounds<'a>> + '_ {
         self.select.iter()
     }
 }
@@ -500,6 +536,12 @@ impl<'a> SelectInfoElemBounds<'a> {
         }
     }
 
+    /// Checks if the selection element is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Retrieves the index at the specified position.
     pub fn index(&self, i: usize) -> usize {
         match self {
@@ -512,35 +554,49 @@ impl<'a> SelectInfoElemBounds<'a> {
     pub fn is_full(&self, bound: usize) -> bool {
         match self {
             Self::Slice(slice) => slice.start == 0 && slice.end == bound && slice.step == 1,
-            Self::Index(indices) => indices.len() == bound && indices.iter().enumerate().all(|(i, &x)| x == i),
+            Self::Index(indices) => {
+                indices.len() == bound && indices.iter().enumerate().all(|(i, &x)| x == i)
+            }
         }
     }
 
     /// Converts the selection element into a vector of indices.
     pub fn to_vec(&self) -> Vec<usize> {
         match self {
-            Self::Index(idx) => idx.iter().copied().collect(),
-            Self::Slice(slice) => if slice.step > 0 {
-                (slice.start..slice.end).step_by(slice.step as usize).collect()
-            } else {
-                (slice.start..slice.end).step_by(slice.step.abs() as usize).rev().collect()
-            },
+            Self::Index(idx) => idx.to_vec(),
+            Self::Slice(slice) => {
+                if slice.step > 0 {
+                    (slice.start..slice.end)
+                        .step_by(slice.step as usize)
+                        .collect()
+                } else {
+                    (slice.start..slice.end)
+                        .step_by(slice.step.unsigned_abs())
+                        .rev()
+                        .collect()
+                }
+            }
         }
     }
 
     /// Returns an iterator over the indices represented by the selection element.
-    pub fn iter(&self) -> Box<dyn ExactSizeIterator<Item=usize> + 'a> {
+    pub fn iter(&self) -> Box<dyn ExactSizeIterator<Item = usize> + 'a> {
         match self {
             Self::Index(idx) => Box::new(idx.iter().copied()),
-            Self::Slice(slice) => if slice.step > 0 {
-                Box::new((slice.start..slice.end).step_by(slice.step as usize))
-            } else {
-                Box::new((slice.start..slice.end).step_by(slice.step.abs() as usize).rev())
-            },
+            Self::Slice(slice) => {
+                if slice.step > 0 {
+                    Box::new((slice.start..slice.end).step_by(slice.step as usize))
+                } else {
+                    Box::new(
+                        (slice.start..slice.end)
+                            .step_by(slice.step.unsigned_abs())
+                            .rev(),
+                    )
+                }
+            }
         }
     }
 }
-
 
 /// `SliceBounds` represents bounds-aware slicing information, holding the start, end, and step values.
 #[derive(Debug, Copy, Clone)]
@@ -550,17 +606,17 @@ pub struct SliceBounds {
     pub step: isize,
 }
 
-impl Into<SliceInfoElem> for SliceBounds {
+impl From<SliceBounds> for SliceInfoElem {
     /// Converts `SliceBounds` into a `SliceInfoElem`.
-    fn into(self) -> SliceInfoElem {
+    fn from(val: SliceBounds) -> Self {
         Slice {
-            start: self.start as isize,
-            end: Some(self.end as isize),
-            step: self.step,
-        }.into()
+            start: val.start as isize,
+            end: Some(val.end as isize),
+            step: val.step,
+        }
+        .into()
     }
 }
-
 
 impl SliceBounds {
     /// Constructs a new `SliceBounds` from a `Slice` and an axis bound.
@@ -581,7 +637,9 @@ impl SliceBounds {
     }
 
     pub(crate) fn len(&self) -> usize {
-        (self.end - self.start).checked_div(self.step.unsigned_abs()).unwrap()
+        (self.end - self.start)
+            .checked_div(self.step.unsigned_abs())
+            .unwrap()
     }
 
     pub(crate) fn index(&self, i: usize) -> usize {
@@ -601,9 +659,9 @@ pub const SLICE_FULL: Slice = Slice {
 };
 
 /// find unique indices and return the mapping
-/// 
+///
 /// Example:
-/// 
+///
 /// (unique_idx, mapping) = unique_indices_sorted(ori_idx, upper_bound)
 /// assert_eq!(ori_idx, mapping.iter().map(|x| unique_idx[*x]).collect::<Vec<usize>>())
 fn _unique_indices_sorted(indices: &[usize], upper_bound: usize) -> (Vec<usize>, Vec<usize>) {
@@ -612,7 +670,11 @@ fn _unique_indices_sorted(indices: &[usize], upper_bound: usize) -> (Vec<usize>,
     for i in indices {
         mask[*i] = *i;
     }
-    let unique = mask.iter().filter(|x| **x != upper_bound).map(|x| *x).collect();
+    let unique = mask
+        .iter()
+        .filter(|x| **x != upper_bound)
+        .copied()
+        .collect();
 
     // Find the new order
     mask.iter_mut().fold(0, |acc, x| {
@@ -665,11 +727,11 @@ fn _unique_indices_sorted(indices: &[usize], upper_bound: usize) -> (Vec<usize>,
 macro_rules! s{
     ( $( $x:expr ),* ) => {
         {
-            let mut temp_vec = Vec::new();
-            $(
-                temp_vec.push($crate::data::SelectInfoElem::from($x));
-            )*
-            $crate::data::SelectInfo(temp_vec)
+            $crate::data::SelectInfo(vec![
+                $(
+                    $crate::data::SelectInfoElem::from($x),
+                )*
+            ])
         }
 
     };
@@ -685,7 +747,7 @@ mod tests {
         fn test_indices(input: Vec<u16>) {
             let max = (*input.iter().max().unwrap_or(&0) as usize) + 1;
             let indices = input.into_iter().map(|x| x as usize).collect::<Vec<_>>();
-            let sorted_expected = indices.iter().map(|x| *x).unique().sorted().collect::<Vec<_>>();
+            let sorted_expected = indices.iter().copied().unique().sorted().collect::<Vec<_>>();
             let (sorted, mapping) = _unique_indices_sorted(indices.as_slice(), max);
             assert_eq!(sorted, sorted_expected);
             assert_eq!(indices, mapping.iter().map(|x| sorted[*x]).collect::<Vec<_>>());

--- a/anndata/src/data/array/sparse/csc.rs
+++ b/anndata/src/data/array/sparse/csc.rs
@@ -278,8 +278,7 @@ impl<T: BackendData> Writable for CscMatrix<T> {
             )?;
         } else {
             panic!(
-                "The number of rows ({}) is too large to be stored as i64",
-                num_rows
+                "The number of rows ({num_rows}) is too large to be stored as i64"
             );
         }
 
@@ -315,11 +314,10 @@ impl<T: BackendData> Readable for CscMatrix<T> {
                 indices,
                 data,
             )
-            .map_err(|e| anyhow::anyhow!("{}", e))
+            .map_err(|e| anyhow::anyhow!("{e}"))
         } else {
             bail!(
-                "cannot read csc matrix from container with data type {:?}",
-                data_type
+                "cannot read csc matrix from container with data type {data_type:?}"
             )
         }
     }
@@ -387,8 +385,7 @@ impl<T: BackendData> ReadableArray for CscMatrix<T> {
             Ok(data)
         } else {
             bail!(
-                "cannot read csc matrix from container with data type {:?}",
-                data_type
+                "cannot read csc matrix from container with data type {data_type:?}"
             )
         }
     }

--- a/anndata/src/data/array/sparse/csc.rs
+++ b/anndata/src/data/array/sparse/csc.rs
@@ -277,9 +277,7 @@ impl<T: BackendData> Writable for CscMatrix<T> {
                 get_default_write_config(),
             )?;
         } else {
-            panic!(
-                "The number of rows ({num_rows}) is too large to be stored as i64"
-            );
+            panic!("The number of rows ({num_rows}) is too large to be stored as i64");
         }
 
         Ok(DataContainer::Group(group))
@@ -316,9 +314,7 @@ impl<T: BackendData> Readable for CscMatrix<T> {
             )
             .map_err(|e| anyhow::anyhow!("{e}"))
         } else {
-            bail!(
-                "cannot read csc matrix from container with data type {data_type:?}"
-            )
+            bail!("cannot read csc matrix from container with data type {data_type:?}")
         }
     }
 }
@@ -384,9 +380,7 @@ impl<T: BackendData> ReadableArray for CscMatrix<T> {
             };
             Ok(data)
         } else {
-            bail!(
-                "cannot read csc matrix from container with data type {data_type:?}"
-            )
+            bail!("cannot read csc matrix from container with data type {data_type:?}")
         }
     }
 }

--- a/anndata/src/data/array/sparse/csc.rs
+++ b/anndata/src/data/array/sparse/csc.rs
@@ -2,14 +2,14 @@ use std::collections::HashMap;
 
 use crate::backend::*;
 use crate::data::{
-    array::utils::{cs_major_index, cs_major_minor_index, cs_major_slice},
+    SelectInfoBounds, SelectInfoElemBounds,
     array::DynScalar,
+    array::utils::{cs_major_index, cs_major_minor_index, cs_major_slice},
     data_traits::*,
     slice::{SelectInfoElem, Shape},
-    SelectInfoBounds, SelectInfoElemBounds,
 };
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use nalgebra_sparse::csc::CscMatrix;
 use nalgebra_sparse::pattern::SparsityPattern;
 use ndarray::Ix1;
@@ -51,14 +51,10 @@ impl<T: BackendData + Clone> Selectable for CscMatrix<T> {
                     if step == 1 {
                         let (offsets, indices, data) =
                             cs_major_slice(start, end, col_offsets, row_indices, data);
-                        (
-                            offsets,
-                            indices.iter().copied().collect(),
-                            data.iter().cloned().collect(),
-                        )
+                        (offsets, indices.to_vec(), data.to_vec())
                     } else if step < 0 {
                         cs_major_index(
-                            (start..end).step_by(step.abs() as usize).rev(),
+                            (start..end).step_by(step.unsigned_abs()).rev(),
                             col_offsets,
                             row_indices,
                             data,
@@ -90,8 +86,8 @@ impl<T: BackendData + Clone> Selectable for CscMatrix<T> {
                             &SelectInfoElemBounds::Slice(row) => {
                                 if row.step < 0 {
                                     cs_major_minor_index(
-                                        (col_start..col_end).step_by(col_step.abs() as usize).rev(),
-                                        (row.start..row.end).step_by(row.step.abs() as usize).rev(),
+                                        (col_start..col_end).step_by(col_step.unsigned_abs()).rev(),
+                                        (row.start..row.end).step_by(row.step.unsigned_abs()).rev(),
                                         self.nrows(),
                                         col_offsets,
                                         row_indices,
@@ -99,7 +95,7 @@ impl<T: BackendData + Clone> Selectable for CscMatrix<T> {
                                     )
                                 } else {
                                     cs_major_minor_index(
-                                        (col_start..col_end).step_by(col_step.abs() as usize).rev(),
+                                        (col_start..col_end).step_by(col_step.unsigned_abs()).rev(),
                                         (row.start..row.end).step_by(row.step as usize),
                                         self.nrows(),
                                         col_offsets,
@@ -109,7 +105,7 @@ impl<T: BackendData + Clone> Selectable for CscMatrix<T> {
                                 }
                             }
                             SelectInfoElemBounds::Index(idx) => cs_major_minor_index(
-                                (col_start..col_end).step_by(col_step.abs() as usize).rev(),
+                                (col_start..col_end).step_by(col_step.unsigned_abs()).rev(),
                                 idx.iter().copied(),
                                 self.nrows(),
                                 col_offsets,
@@ -124,7 +120,7 @@ impl<T: BackendData + Clone> Selectable for CscMatrix<T> {
                                 if row.step < 0 {
                                     cs_major_minor_index(
                                         (col_start..col_end).step_by(col_step as usize),
-                                        (row.start..row.end).step_by(row.step.abs() as usize).rev(),
+                                        (row.start..row.end).step_by(row.step.unsigned_abs()).rev(),
                                         self.nrows(),
                                         col_offsets,
                                         row_indices,
@@ -157,7 +153,7 @@ impl<T: BackendData + Clone> Selectable for CscMatrix<T> {
                         if row.step < 0 {
                             cs_major_minor_index(
                                 i.iter().copied(),
-                                (row.start..row.end).step_by(row.step.abs() as usize).rev(),
+                                (row.start..row.end).step_by(row.step.unsigned_abs()).rev(),
                                 self.nrows(),
                                 col_offsets,
                                 row_indices,
@@ -269,7 +265,7 @@ impl<T: BackendData> Writable for CscMatrix<T> {
                     .map(|x| TryInto::<i64>::try_into(*x).unwrap())
                     .collect::<Vec<_>>()
                     .into(),
-                    get_default_write_config(),
+                get_default_write_config(),
             )?;
             group.new_array_dataset(
                 "indices",
@@ -278,7 +274,7 @@ impl<T: BackendData> Writable for CscMatrix<T> {
                     .map(|x| (*x) as i64)
                     .collect::<Vec<_>>()
                     .into(),
-                    get_default_write_config(),
+                get_default_write_config(),
             )?;
         } else {
             panic!(
@@ -408,8 +404,8 @@ mod csc_matrix_index_tests {
     use nalgebra::base::DMatrix;
     use nalgebra_sparse::CooMatrix;
     use ndarray::Array;
-    use ndarray_rand::rand_distr::Uniform;
     use ndarray_rand::RandomExt;
+    use ndarray_rand::rand_distr::Uniform;
 
     fn csc_select<I1, I2>(csc: &CscMatrix<i64>, row_indices: I1, col_indices: I2) -> CscMatrix<i64>
     where
@@ -466,7 +462,8 @@ mod csc_matrix_index_tests {
             let values = Array::random(nnz, Uniform::new(-10000, 10000).unwrap()).to_vec();
 
             let csc_matrix: CscMatrix<i64> =
-                (&CooMatrix::try_from_triplets(n, m, row_indices, col_indices, values).unwrap()).into();
+                (&CooMatrix::try_from_triplets(n, m, row_indices, col_indices, values).unwrap())
+                    .into();
 
             // Row slice
             assert_csc_eq(

--- a/anndata/src/data/array/sparse/csr.rs
+++ b/anndata/src/data/array/sparse/csr.rs
@@ -289,8 +289,7 @@ impl<T: BackendData> Writable for CsrMatrix<T> {
             )?;
         } else {
             panic!(
-                "The number of columns ({}) is too large to be stored as i64",
-                num_cols
+                "The number of columns ({num_cols}) is too large to be stored as i64"
             );
         }
 
@@ -326,11 +325,10 @@ impl<T: BackendData> Readable for CsrMatrix<T> {
                 indices,
                 data,
             )
-            .map_err(|e| anyhow!("cannot read csr matrix: {}", e))
+            .map_err(|e| anyhow!("cannot read csr matrix: {e}"))
         } else {
             bail!(
-                "cannot read csr matrix from container with data type {:?}",
-                data_type
+                "cannot read csr matrix from container with data type {data_type:?}"
             )
         }
     }
@@ -398,8 +396,7 @@ impl<T: BackendData> ReadableArray for CsrMatrix<T> {
             Ok(data)
         } else {
             bail!(
-                "cannot read csr matrix from container with data type {:?}",
-                data_type
+                "cannot read csr matrix from container with data type {data_type:?}"
             )
         }
     }
@@ -418,7 +415,7 @@ impl<T: BackendData + Clone + ToPrimitive> ArrayArithmetic for CsrMatrix<T> {
 
     fn sum_axis(&self, axis: usize) -> Result<ArrayD<f64>> {
         if axis >= 2 {
-            anyhow::bail!("axis {} out of bounds", axis);
+            anyhow::bail!("axis {axis} out of bounds");
         }
 
         match axis {
@@ -445,7 +442,7 @@ impl<T: BackendData + Clone + ToPrimitive> ArrayArithmetic for CsrMatrix<T> {
                 })
                 .collect::<Array1<f64>>()
                 .into_dyn()),
-            _ => anyhow::bail!("axis {} is out of bounds for 2D array", axis),
+            _ => anyhow::bail!("axis {axis} is out of bounds for 2D array"),
         }
     }
 

--- a/anndata/src/data/array/sparse/csr.rs
+++ b/anndata/src/data/array/sparse/csr.rs
@@ -288,9 +288,7 @@ impl<T: BackendData> Writable for CsrMatrix<T> {
                 get_default_write_config(),
             )?;
         } else {
-            panic!(
-                "The number of columns ({num_cols}) is too large to be stored as i64"
-            );
+            panic!("The number of columns ({num_cols}) is too large to be stored as i64");
         }
 
         Ok(DataContainer::Group(group))
@@ -327,9 +325,7 @@ impl<T: BackendData> Readable for CsrMatrix<T> {
             )
             .map_err(|e| anyhow!("cannot read csr matrix: {e}"))
         } else {
-            bail!(
-                "cannot read csr matrix from container with data type {data_type:?}"
-            )
+            bail!("cannot read csr matrix from container with data type {data_type:?}")
         }
     }
 }
@@ -395,9 +391,7 @@ impl<T: BackendData> ReadableArray for CsrMatrix<T> {
             };
             Ok(data)
         } else {
-            bail!(
-                "cannot read csr matrix from container with data type {data_type:?}"
-            )
+            bail!("cannot read csr matrix from container with data type {data_type:?}")
         }
     }
 }

--- a/anndata/src/data/array/sparse/csr.rs
+++ b/anndata/src/data/array/sparse/csr.rs
@@ -53,14 +53,10 @@ impl<T: Clone> Selectable for CsrMatrix<T> {
                     if step == 1 {
                         let (offsets, indices, data) =
                             cs_major_slice(start, end, row_offsets, col_indices, data);
-                        (
-                            offsets,
-                            indices.iter().copied().collect(),
-                            data.iter().cloned().collect(),
-                        )
+                        (offsets, indices.to_vec(), data.to_vec())
                     } else if step < 0 {
                         cs_major_index(
-                            (start..end).step_by(step.abs() as usize).rev(),
+                            (start..end).step_by(step.unsigned_abs()).rev(),
                             row_offsets,
                             col_indices,
                             data,
@@ -90,8 +86,8 @@ impl<T: Clone> Selectable for CsrMatrix<T> {
                             &SelectInfoElemBounds::Slice(col) => {
                                 if col.step < 0 {
                                     cs_major_minor_index(
-                                        (row_start..row_end).step_by(row_step.abs() as usize).rev(),
-                                        (col.start..col.end).step_by(col.step.abs() as usize).rev(),
+                                        (row_start..row_end).step_by(row_step.unsigned_abs()).rev(),
+                                        (col.start..col.end).step_by(col.step.unsigned_abs()).rev(),
                                         self.ncols(),
                                         row_offsets,
                                         col_indices,
@@ -99,7 +95,7 @@ impl<T: Clone> Selectable for CsrMatrix<T> {
                                     )
                                 } else {
                                     cs_major_minor_index(
-                                        (row_start..row_end).step_by(row_step.abs() as usize).rev(),
+                                        (row_start..row_end).step_by(row_step.unsigned_abs()).rev(),
                                         (col.start..col.end).step_by(col.step as usize),
                                         self.ncols(),
                                         row_offsets,
@@ -109,7 +105,7 @@ impl<T: Clone> Selectable for CsrMatrix<T> {
                                 }
                             }
                             SelectInfoElemBounds::Index(idx) => cs_major_minor_index(
-                                (row_start..row_end).step_by(row_step.abs() as usize).rev(),
+                                (row_start..row_end).step_by(row_step.unsigned_abs()).rev(),
                                 idx.iter().copied(),
                                 self.ncols(),
                                 row_offsets,
@@ -123,7 +119,7 @@ impl<T: Clone> Selectable for CsrMatrix<T> {
                                 if col.step < 0 {
                                     cs_major_minor_index(
                                         (row_start..row_end).step_by(row_step as usize),
-                                        (col.start..col.end).step_by(col.step.abs() as usize).rev(),
+                                        (col.start..col.end).step_by(col.step.unsigned_abs()).rev(),
                                         self.ncols(),
                                         row_offsets,
                                         col_indices,
@@ -156,7 +152,7 @@ impl<T: Clone> Selectable for CsrMatrix<T> {
                         if col.step < 0 {
                             cs_major_minor_index(
                                 i.iter().copied(),
-                                (col.start..col.end).step_by(col.step.abs() as usize).rev(),
+                                (col.start..col.end).step_by(col.step.unsigned_abs()).rev(),
                                 self.ncols(),
                                 row_offsets,
                                 col_indices,
@@ -280,7 +276,7 @@ impl<T: BackendData> Writable for CsrMatrix<T> {
                     .map(|x| TryInto::<i64>::try_into(*x).unwrap())
                     .collect::<Vec<_>>()
                     .into(),
-                    get_default_write_config(),
+                get_default_write_config(),
             )?;
             group.new_array_dataset(
                 "indices",
@@ -289,7 +285,7 @@ impl<T: BackendData> Writable for CsrMatrix<T> {
                     .map(|x| (*x) as i64)
                     .collect::<Vec<_>>()
                     .into(),
-                    get_default_write_config(),
+                get_default_write_config(),
             )?;
         } else {
             panic!(
@@ -414,7 +410,10 @@ impl<T: BackendData> WritableArray for CsrMatrix<T> {}
 
 impl<T: BackendData + Clone + ToPrimitive> ArrayArithmetic for CsrMatrix<T> {
     fn sum(&self) -> f64 {
-        self.values().iter().map(|x| <f64 as NumCast>::from(x.clone()).unwrap()).sum()
+        self.values()
+            .iter()
+            .map(|x| <f64 as NumCast>::from(x.clone()).unwrap())
+            .sum()
     }
 
     fn sum_axis(&self, axis: usize) -> Result<ArrayD<f64>> {
@@ -438,7 +437,12 @@ impl<T: BackendData + Clone + ToPrimitive> ArrayArithmetic for CsrMatrix<T> {
             }
             1 => Ok(self
                 .row_iter()
-                .map(|row| row.values().iter().map(|v| <f64 as NumCast>::from(v.clone()).unwrap()).sum())
+                .map(|row| {
+                    row.values()
+                        .iter()
+                        .map(|v| <f64 as NumCast>::from(v.clone()).unwrap())
+                        .sum()
+                })
                 .collect::<Array1<f64>>()
                 .into_dyn()),
             _ => anyhow::bail!("axis {} is out of bounds for 2D array", axis),

--- a/anndata/src/data/array/sparse/dynamic.rs
+++ b/anndata/src/data/array/sparse/dynamic.rs
@@ -7,7 +7,7 @@ use crate::data::{
     slice::{SelectInfoElem, Shape},
 };
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use nalgebra_sparse::csc::CscMatrix;
 use nalgebra_sparse::csr::CsrMatrix;
 use ndarray::ArrayD;
@@ -387,9 +387,9 @@ impl ReadableArray for DynCscMatrix {
     }
 }
 
-////////////////////////////////////////////////////////////////////////////////
+//-----------------------------------------------------------------------------
 // ArrayConvert implementations
-////////////////////////////////////////////////////////////////////////////////
+//-----------------------------------------------------------------------------
 
 macro_rules! impl_arrayconvert {
     ($($ty:ident, $fun:expr),*) => {
@@ -463,7 +463,7 @@ where
     let (pattern, values) = csr.into_pattern_and_values();
     let out = CsrMatrix::try_from_pattern_and_values(
         pattern,
-        values.into_iter().map(|x| f(x)).collect::<Result<_, _>>()?,
+        values.into_iter().map(f).collect::<Result<_, _>>()?,
     )
     .unwrap();
     Ok(out)
@@ -476,7 +476,7 @@ where
     let (pattern, values) = csc.into_pattern_and_values();
     let out = CscMatrix::try_from_pattern_and_values(
         pattern,
-        values.into_iter().map(|x| f(x)).collect::<Result<_, _>>()?,
+        values.into_iter().map(f).collect::<Result<_, _>>()?,
     )
     .unwrap();
     Ok(out)

--- a/anndata/src/data/array/sparse/mod.rs
+++ b/anndata/src/data/array/sparse/mod.rs
@@ -1,7 +1,7 @@
-mod csr;
 mod csc;
-mod noncanonical;
+mod csr;
 mod dynamic;
+mod noncanonical;
 
-pub use noncanonical::*;
 pub use dynamic::*;
+pub use noncanonical::*;

--- a/anndata/src/data/array/sparse/noncanonical.rs
+++ b/anndata/src/data/array/sparse/noncanonical.rs
@@ -711,8 +711,7 @@ impl<T: BackendData> Writable for CsrNonCanonical<T> {
             )?;
         } else {
             panic!(
-                "The number of columns ({}) is too large to be stored as i64",
-                num_cols
+                "The number of columns ({num_cols}) is too large to be stored as i64"
             );
         }
 

--- a/anndata/src/data/array/sparse/noncanonical.rs
+++ b/anndata/src/data/array/sparse/noncanonical.rs
@@ -2,13 +2,13 @@ use std::collections::HashMap;
 
 use crate::backend::*;
 use crate::data::{
+    SelectInfoBounds, SelectInfoElemBounds,
     array::utils::{cs_major_index, cs_major_minor_index, cs_major_slice},
     data_traits::*,
     slice::{SelectInfoElem, Shape},
-    SelectInfoBounds, SelectInfoElemBounds,
 };
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use nalgebra_sparse::pattern::SparsityPattern;
 use nalgebra_sparse::{coo::CooMatrix, csr::CsrMatrix};
 use ndarray::Ix1;
@@ -159,7 +159,7 @@ impl Readable for DynCsrNonCanonical {
                     };
                 }
                 crate::macros::dyn_match!(group.open_dataset("data")?.dtype()?, ScalarType, fun)
-            },
+            }
             _ => bail!("cannot read csr matrix from non-group container"),
         }
     }
@@ -466,14 +466,10 @@ impl<T: Clone> Selectable for CsrNonCanonical<T> {
                     if step == 1 {
                         let (offsets, indices, data) =
                             cs_major_slice(start, end, row_offsets, col_indices, data);
-                        (
-                            offsets,
-                            indices.iter().copied().collect(),
-                            data.iter().cloned().collect(),
-                        )
+                        (offsets, indices.to_vec(), data.to_vec())
                     } else if step < 0 {
                         cs_major_index(
-                            (start..end).step_by(step.abs() as usize).rev(),
+                            (start..end).step_by(step.unsigned_abs()).rev(),
                             row_offsets,
                             col_indices,
                             data,
@@ -503,8 +499,8 @@ impl<T: Clone> Selectable for CsrNonCanonical<T> {
                             &SelectInfoElemBounds::Slice(col) => {
                                 if col.step < 0 {
                                     cs_major_minor_index(
-                                        (row_start..row_end).step_by(row_step.abs() as usize).rev(),
-                                        (col.start..col.end).step_by(col.step.abs() as usize).rev(),
+                                        (row_start..row_end).step_by(row_step.unsigned_abs()).rev(),
+                                        (col.start..col.end).step_by(col.step.unsigned_abs()).rev(),
                                         self.ncols(),
                                         row_offsets,
                                         col_indices,
@@ -512,7 +508,7 @@ impl<T: Clone> Selectable for CsrNonCanonical<T> {
                                     )
                                 } else {
                                     cs_major_minor_index(
-                                        (row_start..row_end).step_by(row_step.abs() as usize).rev(),
+                                        (row_start..row_end).step_by(row_step.unsigned_abs()).rev(),
                                         (col.start..col.end).step_by(col.step as usize),
                                         self.ncols(),
                                         row_offsets,
@@ -522,7 +518,7 @@ impl<T: Clone> Selectable for CsrNonCanonical<T> {
                                 }
                             }
                             SelectInfoElemBounds::Index(idx) => cs_major_minor_index(
-                                (row_start..row_end).step_by(row_step.abs() as usize).rev(),
+                                (row_start..row_end).step_by(row_step.unsigned_abs()).rev(),
                                 idx.iter().copied(),
                                 self.ncols(),
                                 row_offsets,
@@ -536,7 +532,7 @@ impl<T: Clone> Selectable for CsrNonCanonical<T> {
                                 if col.step < 0 {
                                     cs_major_minor_index(
                                         (row_start..row_end).step_by(row_step as usize),
-                                        (col.start..col.end).step_by(col.step.abs() as usize).rev(),
+                                        (col.start..col.end).step_by(col.step.unsigned_abs()).rev(),
                                         self.ncols(),
                                         row_offsets,
                                         col_indices,
@@ -569,7 +565,7 @@ impl<T: Clone> Selectable for CsrNonCanonical<T> {
                         if col.step < 0 {
                             cs_major_minor_index(
                                 i.iter().copied(),
-                                (col.start..col.end).step_by(col.step.abs() as usize).rev(),
+                                (col.start..col.end).step_by(col.step.unsigned_abs()).rev(),
                                 self.ncols(),
                                 row_offsets,
                                 col_indices,
@@ -702,7 +698,7 @@ impl<T: BackendData> Writable for CsrNonCanonical<T> {
                     .map(|x| TryInto::<i64>::try_into(*x).unwrap())
                     .collect::<Vec<_>>()
                     .into(),
-                    get_default_write_config(),
+                get_default_write_config(),
             )?;
             group.new_array_dataset(
                 "indices",
@@ -711,7 +707,7 @@ impl<T: BackendData> Writable for CsrNonCanonical<T> {
                     .map(|x| (*x) as i64)
                     .collect::<Vec<_>>()
                     .into(),
-                    get_default_write_config(),
+                get_default_write_config(),
             )?;
         } else {
             panic!(

--- a/anndata/src/data/array/sparse/noncanonical.rs
+++ b/anndata/src/data/array/sparse/noncanonical.rs
@@ -710,9 +710,7 @@ impl<T: BackendData> Writable for CsrNonCanonical<T> {
                 get_default_write_config(),
             )?;
         } else {
-            panic!(
-                "The number of columns ({num_cols}) is too large to be stored as i64"
-            );
+            panic!("The number of columns ({num_cols}) is too large to be stored as i64");
         }
 
         Ok(DataContainer::Group(group))

--- a/anndata/src/data/array/utils.rs
+++ b/anndata/src/data/array/utils.rs
@@ -460,7 +460,7 @@ where
                 let csr = CsrNonCanonical::from_csr_data(nrows, ncols, indptr, indices, data);
                 Ok(csr.into())
             }
-            _ => Err(anyhow!("cannot read csr matrix: {}", e)),
+            _ => Err(anyhow!("cannot read csr matrix: {e}")),
         },
     }
 }

--- a/anndata/src/data/array/utils.rs
+++ b/anndata/src/data/array/utils.rs
@@ -1,12 +1,12 @@
+use crate::ArrayData;
 use crate::backend::{Backend, BackendData, DatasetOp, GroupOp, WriteConfig};
 use crate::data::{SelectInfoElem, Shape};
-use crate::ArrayData;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use itertools::Itertools;
 use nalgebra_sparse::{
-    pattern::{SparsityPattern, SparsityPatternFormatError},
     CsrMatrix,
+    pattern::{SparsityPattern, SparsityPatternFormatError},
 };
 use ndarray::{Array2, ArrayView, RemoveAxis};
 use smallvec::SmallVec;
@@ -36,7 +36,7 @@ impl<B: Backend, T: BackendData> ExtendableDataset<B, T> {
         )?;
         Ok(Self {
             dataset,
-            size: std::iter::repeat(0).take(capacity.ndim()).collect(),
+            size: std::iter::repeat_n(0, capacity.ndim()).collect(),
             capacity,
             elem_type: std::marker::PhantomData,
         })
@@ -245,14 +245,13 @@ pub(crate) fn cs_major_minor_index2<T: Clone>(
     offsets: &[usize],
     indices: &[usize],
     data: &[T],
-) -> (Vec<usize>, Vec<usize>, Vec<T>)
-{
+) -> (Vec<usize>, Vec<usize>, Vec<T>) {
     let num_added_minors = minor_idx.iter().filter(|&j| j.is_none()).count();
     let len_minor = len_minor + num_added_minors;
 
     // Compute the occurrence of each minor index, as the same index can occur multiple times
     let mut minor_idx_count = vec![0; len_minor];
-    minor_idx_count[(len_minor-num_added_minors) .. len_minor].fill(1);
+    minor_idx_count[(len_minor - num_added_minors)..len_minor].fill(1);
     minor_idx.iter().for_each(|j| {
         if let Some(j) = j {
             minor_idx_count[*j] += 1;
@@ -264,8 +263,9 @@ pub(crate) fn cs_major_minor_index2<T: Clone>(
     let new_offsets = std::iter::once(0)
         .chain(major_idx.iter().map(|i| {
             if let Some(i) = i {
-                (offsets[*i]..offsets[i + 1]).for_each(|jj| new_nnz += minor_idx_count[indices[jj]]);
-            } 
+                (offsets[*i]..offsets[i + 1])
+                    .for_each(|jj| new_nnz += minor_idx_count[indices[jj]]);
+            }
             new_nnz
         }))
         .collect();
@@ -405,7 +405,7 @@ pub(crate) fn sort_lane<T: Clone>(
     apply_permutation(values_result, values, permutation);
 }
 
-/// Helper functions for sparse matrix computations
+// Helper functions for sparse matrix computations
 
 /// permutes entries of in_slice according to permutation slice and puts them to out_slice
 #[inline]
@@ -563,26 +563,21 @@ pub(crate) fn array_major_minor_index<T: Clone>(
     minor_idx: &[Option<usize>],
     data: &Array2<T>,
     fill_value: &T,
-) -> Array2<T>
-{
-    Array2::from_shape_fn(
-        (major_idx.len(), minor_idx.len()),
-        |(i, j)| {
-            if let (Some(i), Some(j)) = (major_idx[i], minor_idx[j]) {
-                data.get((i, j)).unwrap().clone()
-            } else {
-                fill_value.clone()
-            }
-        },
-    )
+) -> Array2<T> {
+    Array2::from_shape_fn((major_idx.len(), minor_idx.len()), |(i, j)| {
+        if let (Some(i), Some(j)) = (major_idx[i], minor_idx[j]) {
+            data.get((i, j)).unwrap().clone()
+        } else {
+            fill_value.clone()
+        }
+    })
 }
 
 pub(crate) fn array_major_minor_index_default<T: Default + Clone>(
     major_idx: &[Option<usize>],
     minor_idx: &[Option<usize>],
     data: &Array2<T>,
-) -> Array2<T>
-{
+) -> Array2<T> {
     array_major_minor_index(major_idx, minor_idx, data, &T::default())
 }
 

--- a/anndata/src/data/data_traits.rs
+++ b/anndata/src/data/data_traits.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use crate::backend::{AttributeOp, Backend, DataContainer, DataType, GroupOp};
 use crate::data::{
-    array::slice::{SelectInfoElem, Shape},
     array::DynScalar,
+    array::slice::{SelectInfoElem, Shape},
 };
 
 use anyhow::Result;
@@ -107,9 +107,9 @@ where
     }
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// Traits for arrays
-////////////////////////////////////////////////////////////////////////////////
+//-----------------------------------------------------------------------------
+// Traits for arrays
+//-----------------------------------------------------------------------------
 
 /// Anything that has a shape.
 pub trait HasShape {

--- a/anndata/src/data/index.rs
+++ b/anndata/src/data/index.rs
@@ -174,7 +174,7 @@ impl IntoIterator for Index {
         match self {
             Index::Intervals(map) => {
                 Box::new(map.intervals.into_iter().flat_map(|(k, interval)| {
-                    interval.map(move |(start, end)| format!("{}:{}-{}", k, start, end))
+                    interval.map(move |(start, end)| format!("{k}:{start}-{end}"))
                 }))
             }
             Index::List(list) => Box::new(list.items.into_iter()),
@@ -477,7 +477,7 @@ mod tests {
         if n == 0 {
             Just(Index::empty()).boxed()
         } else {
-            let list = (0..n).map(|i| format!("i_{}", i)).collect();
+            let list = (0..n).map(|i| format!("i_{i}")).collect();
             let range = n.into();
             let interval = (0..n).prop_flat_map(move |i| {
                 (Just(i), (0..n - i)).prop_flat_map(move |(a, b)| {

--- a/anndata/src/data/index.rs
+++ b/anndata/src/data/index.rs
@@ -1,20 +1,20 @@
 use crate::data::array::slice::{SelectInfoElem, SliceBounds};
 
+use indexmap::IndexMap;
+use itertools::Itertools;
 use ndarray::Slice;
+use smallvec::SmallVec;
+use std::borrow::Borrow;
+use std::cmp::Eq;
+use std::hash::Hash;
 use std::ops::Deref;
 use std::{collections::HashMap, ops::Range};
-use indexmap::IndexMap;
-use smallvec::SmallVec;
-use itertools::Itertools;
-use std::borrow::Borrow;
-use std::hash::Hash;
-use std::cmp::Eq;
 
 use super::SelectInfoElemBounds;
 
 #[derive(Clone, Debug)]
 pub enum Index {
-    Intervals(NamedIntervals),
+    Intervals(Box<NamedIntervals>),
     List(List<String>),
     Range(Range<usize>),
 }
@@ -59,7 +59,10 @@ impl Index {
         match self {
             Index::Intervals(map) => {
                 let query: SmallVec<[&str; 3]> = key.split(&['-', ':']).collect();
-                map.get_index(query[0], (query[1].parse().unwrap(), query[2].parse().unwrap()))
+                map.get_index(
+                    query[0],
+                    (query[1].parse().unwrap(), query[2].parse().unwrap()),
+                )
             }
             Index::List(list) => list.get_index(key),
             Index::Range(range) => {
@@ -69,7 +72,7 @@ impl Index {
                 } else {
                     None
                 }
-            },
+            }
         }
     }
 
@@ -78,8 +81,8 @@ impl Index {
             SelectInfoElemBounds::Slice(slice) => self.slice(slice.start, slice.end),
             SelectInfoElemBounds::Index(index) => {
                 let vec = self.clone().into_vec();
-                index.into_iter().map(|i| vec[*i].clone()).collect()
-            },
+                index.iter().map(|i| vec[*i].clone()).collect()
+            }
         }
     }
 
@@ -95,19 +98,26 @@ impl Index {
         match self {
             Index::Intervals(intervals) => {
                 let (o1, i1) = intervals.accum_length.ix(&start);
-                let (o2, i2) = intervals.accum_length.ix(&(end-1));
+                let (o2, i2) = intervals.accum_length.ix(&(end - 1));
                 if o1 == o2 {
                     let (k, interval) = intervals.intervals.get_index(o1).unwrap();
-                    std::iter::once((k.to_owned(), interval.slice(i1, i2+1))).collect()
+                    std::iter::once((k.to_owned(), interval.slice(i1, i2 + 1))).collect()
                 } else {
                     let (k1, interval1) = intervals.intervals.get_index(o1).unwrap();
                     let (k2, interval2) = intervals.intervals.get_index(o2).unwrap();
                     std::iter::once((k1.to_owned(), interval1.slice(i1, interval1.len())))
-                        .chain(intervals.intervals.iter().skip(o1+1).take(o2-o1-1).map(|(k,v)| (k.to_owned(), v.clone())))
-                        .chain(std::iter::once((k2.to_owned(), interval2.slice(0, i2+1))))
+                        .chain(
+                            intervals
+                                .intervals
+                                .iter()
+                                .skip(o1 + 1)
+                                .take(o2 - o1 - 1)
+                                .map(|(k, v)| (k.to_owned(), v.clone())),
+                        )
+                        .chain(std::iter::once((k2.to_owned(), interval2.slice(0, i2 + 1))))
                         .collect()
                 }
-            },
+            }
             Index::List(list) => list.items[start..end].iter().cloned().collect(),
             Index::Range(r) => Index::Range(r.start + start..r.start + end),
         }
@@ -115,7 +125,7 @@ impl Index {
 
     pub fn iter(&self) -> Box<dyn Iterator<Item = String> + '_> {
         match self {
-            Index::List(list) => Box::new(list.items.iter().map(|x| x.clone())),
+            Index::List(list) => Box::new(list.items.iter().cloned()),
             _ => self.clone().into_iter(),
         }
     }
@@ -152,7 +162,7 @@ impl FromIterator<String> for Index {
 
 impl<S: Into<String>> FromIterator<(S, Interval)> for Index {
     fn from_iter<T: IntoIterator<Item = (S, Interval)>>(iter: T) -> Self {
-        Self::Intervals(NamedIntervals::from_iter(iter))
+        Self::Intervals(Box::new(NamedIntervals::from_iter(iter)))
     }
 }
 
@@ -162,13 +172,11 @@ impl IntoIterator for Index {
 
     fn into_iter(self) -> Self::IntoIter {
         match self {
-            Index::Intervals(map) => Box::new(
-                map.intervals
-                    .into_iter()
-                    .flat_map(|(k, interval)| 
-                        interval.map(move |(start, end)| format!("{}:{}-{}", k, start, end))
-                    )
-            ),
+            Index::Intervals(map) => {
+                Box::new(map.intervals.into_iter().flat_map(|(k, interval)| {
+                    interval.map(move |(start, end)| format!("{}:{}-{}", k, start, end))
+                }))
+            }
             Index::List(list) => Box::new(list.items.into_iter()),
             Index::Range(range) => Box::new(range.map(|i| i.to_string())),
         }
@@ -191,25 +199,35 @@ impl Deref for NamedIntervals {
 
 impl NamedIntervals {
     pub fn get_index(&self, name: &str, interval: (usize, usize)) -> Option<usize> {
-        self.intervals.get_full(name).and_then(|(i, _, v)|
-            v.get_index(interval).map(|x| x + self.accum_length.0[i])
-        )
+        self.intervals
+            .get_full(name)
+            .and_then(|(i, _, v)| v.get_index(interval).map(|x| x + self.accum_length.0[i]))
     }
 
     pub fn len(&self) -> usize {
         self.accum_length.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.accum_length.is_empty()
     }
 }
 
 impl<S: Into<String>> FromIterator<(S, Interval)> for NamedIntervals {
     fn from_iter<T: IntoIterator<Item = (S, Interval)>>(iter: T) -> Self {
         let mut intervals = IndexMap::new();
-        let accum_length = iter.into_iter().map(|(name, interval)| {
-            let n = interval.len();
-            intervals.insert(name.into(), interval);
-            n
-        }).collect();
-        Self { intervals, accum_length }
+        let accum_length = iter
+            .into_iter()
+            .map(|(name, interval)| {
+                let n = interval.len();
+                intervals.insert(name.into(), interval);
+                n
+            })
+            .collect();
+        Self {
+            intervals,
+            accum_length,
+        }
     }
 }
 
@@ -241,6 +259,10 @@ impl Interval {
         num::integer::div_ceil(self.end - self.start, self.step)
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     fn slice(&self, start: usize, end: usize) -> Self {
         let start = self.start + self.step * start;
         let end = self.start + self.step * end;
@@ -262,7 +284,7 @@ impl Iterator for Interval {
         } else {
             let end = (self.start + self.size).min(self.end);
             let item = (self.start, end);
-            self.start = self.start + self.step;
+            self.start += self.step;
             Some(item)
         }
     }
@@ -282,13 +304,16 @@ impl std::cmp::PartialEq for List<String> {
 
 impl<K: Hash + Eq> List<K> {
     pub fn empty() -> Self {
-        Self { items: vec![], index_map: HashMap::new() } 
+        Self {
+            items: vec![],
+            index_map: HashMap::new(),
+        }
     }
 
-    pub fn get_index<Q: ?Sized>(&self, item: &Q) -> Option<usize>
+    pub fn get_index<Q>(&self, item: &Q) -> Option<usize>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: ?Sized + Hash + Eq,
     {
         self.index_map.get(item).cloned()
     }
@@ -381,19 +406,23 @@ impl VecVecIndex {
         res
     }
 
-    fn split_indices(&self, indices: &[usize]) -> (HashMap<usize, SelectInfoElem>, Option<Vec<usize>>) {
+    fn split_indices(
+        &self,
+        indices: &[usize],
+    ) -> (HashMap<usize, SelectInfoElem>, Option<Vec<usize>>) {
         let (new_indices, orders): (HashMap<usize, SelectInfoElem>, Vec<_>) = indices
-            .into_iter()
+            .iter()
             .map(|x| self.ix(x))
             .enumerate()
             .sorted_by_key(|(_, (x, _))| *x)
-            .into_iter()
             .chunk_by(|(_, (x, _))| *x)
             .into_iter()
             .map(|(outer, inner)| {
-                let (new_indices, order): (Vec<_>, Vec<_>) = inner.map(|(i, (_, x))| (x, i)).unzip();
+                let (new_indices, order): (Vec<_>, Vec<_>) =
+                    inner.map(|(i, (_, x))| (x, i)).unzip();
                 ((outer, new_indices.into()), order)
-            }).unzip();
+            })
+            .unzip();
         let order: Vec<_> = orders.into_iter().flatten().collect();
         if order.as_slice().windows(2).all(|w| w[1] - w[0] == 1) {
             (new_indices, None)
@@ -417,6 +446,10 @@ impl VecVecIndex {
     pub fn len(&self) -> usize {
         *self.0.last().unwrap_or(&0)
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl FromIterator<usize> for VecVecIndex {
@@ -426,7 +459,7 @@ impl FromIterator<usize> for VecVecIndex {
     {
         let index: SmallVec<_> = std::iter::once(0)
             .chain(iter.into_iter().scan(0, |state, x| {
-                *state = *state + x;
+                *state += x;
                 Some(*state)
             }))
             .collect();
@@ -434,12 +467,11 @@ impl FromIterator<usize> for VecVecIndex {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use proptest::strategy::BoxedStrategy;
     use proptest::prelude::*;
+    use proptest::strategy::BoxedStrategy;
 
     fn index_strat(n: usize) -> BoxedStrategy<Index> {
         if n == 0 {
@@ -447,46 +479,83 @@ mod tests {
         } else {
             let list = (0..n).map(|i| format!("i_{}", i)).collect();
             let range = n.into();
-            let interval = (0..n).prop_flat_map(move |i|
+            let interval = (0..n).prop_flat_map(move |i| {
                 (Just(i), (0..n - i)).prop_flat_map(move |(a, b)| {
                     let c = n - a - b;
-                    [a,b,c].into_iter().filter(|x| *x != 0).map(|x|
-                        interval_strat(x)
-                    ).collect::<Vec<_>>().prop_map(move |x|
-                        x.into_iter().enumerate().map(|(i, x)| 
-                            (i.to_string(), x)
-                        ).collect::<Index>()
-                    )
+                    [a, b, c]
+                        .into_iter()
+                        .filter(|x| *x != 0)
+                        .map(interval_strat)
+                        .collect::<Vec<_>>()
+                        .prop_map(move |x| {
+                            x.into_iter()
+                                .enumerate()
+                                .map(|(i, x)| (i.to_string(), x))
+                                .collect::<Index>()
+                        })
                 })
-            );
-            prop_oneof![
-                Just(list),
-                Just(range),
-                interval
-            ].boxed()
+            });
+            prop_oneof![Just(list), Just(range), interval].boxed()
         }
     }
 
     fn interval_strat(n: usize) -> impl Strategy<Value = Interval> {
-        (1 as usize ..100, 1 as usize ..100).prop_map(move |(size, step)|
-            Interval { start: 0, end: n*step, size, step }
-        )
+        (1_usize..100, 1_usize..100).prop_map(move |(size, step)| Interval {
+            start: 0,
+            end: n * step,
+            size,
+            step,
+        })
     }
 
     #[test]
     fn test_example() {
         let index: Index = [
-            ("0", Interval { start: 0, end: 2, size: 1, step: 1 }),
-            ("1", Interval { start: 0, end: 972, size: 1, step: 27 }),
-            ("2", Interval { start: 0, end: 1134, size: 53, step: 18 }),
-        ].into_iter().collect();
+            (
+                "0",
+                Interval {
+                    start: 0,
+                    end: 2,
+                    size: 1,
+                    step: 1,
+                },
+            ),
+            (
+                "1",
+                Interval {
+                    start: 0,
+                    end: 972,
+                    size: 1,
+                    step: 27,
+                },
+            ),
+            (
+                "2",
+                Interval {
+                    start: 0,
+                    end: 1134,
+                    size: 53,
+                    step: 18,
+                },
+            ),
+        ]
+        .into_iter()
+        .collect();
 
         assert_eq!(index.len(), 101);
         assert_eq!(index, index.select(&(0..101).into()));
         assert_eq!(
-            [
-                ("2", Interval {start: 900, end: 1062, step: 18, size: 53})
-            ].into_iter().collect::<Index>(),
+            [(
+                "2",
+                Interval {
+                    start: 900,
+                    end: 1062,
+                    step: 18,
+                    size: 53
+                }
+            )]
+            .into_iter()
+            .collect::<Index>(),
             index.select(&(88..97).into()),
         );
     }
@@ -495,18 +564,17 @@ mod tests {
         if n == 0 {
             Just(Vec::new().into()).boxed()
         } else {
-            let indices = proptest::collection::vec(0..n, 0..2*n).prop_map(|i| i.into());
-            let slice = (0..n).prop_flat_map(move |start| (Just(start), (start+1)..=n).prop_map(|(start, stop)| (start..stop).into()));
-            prop_oneof![
-                indices,
-                slice,
-            ].boxed()
+            let indices = proptest::collection::vec(0..n, 0..2 * n).prop_map(|i| i.into());
+            let slice = (0..n).prop_flat_map(move |start| {
+                (Just(start), (start + 1)..=n).prop_map(|(start, stop)| (start..stop).into())
+            });
+            prop_oneof![indices, slice,].boxed()
         }
     }
 
     #[test]
     fn test_index() {
-        let index = (0 as usize ..500).prop_flat_map(|n| (Just(n), index_strat(n), select_strat(n)));
+        let index = (0_usize..500).prop_flat_map(|n| (Just(n), index_strat(n), select_strat(n)));
         proptest!(ProptestConfig::with_cases(256), |((n, i, slice) in index)| {
             prop_assert_eq!(i.len(), n);
             prop_assert_eq!(i.len(), i.clone().into_vec().len());

--- a/anndata/src/data/mapping.rs
+++ b/anndata/src/data/mapping.rs
@@ -1,18 +1,18 @@
-use crate::backend::{Backend, GroupOp, DataContainer, iter_containers, DataType};
+use crate::backend::{Backend, DataContainer, DataType, GroupOp, iter_containers};
 use crate::data::{Data, Readable, Writable};
 
+use anyhow::Result;
 use std::collections::HashMap;
 use std::ops::Deref;
-use anyhow::Result;
 
 use super::{Element, MetaData};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Mapping(HashMap<String, Data>);
 
-impl Into<HashMap<String, Data>> for Mapping {
-    fn into(self) -> HashMap<String, Data> {
-        self.0
+impl From<Mapping> for HashMap<String, Data> {
+    fn from(val: Mapping) -> Self {
+        val.0
     }
 }
 
@@ -42,15 +42,19 @@ impl Element for Mapping {
 
 impl Readable for Mapping {
     fn read<B: Backend>(container: &DataContainer<B>) -> Result<Self> {
-        let data: Result<_> = iter_containers::<B>(container.as_group()?).map(|(k, v)| {
-            Ok((k.to_owned(), Data::read(&v)?))
-        }).collect();
+        let data: Result<_> = iter_containers::<B>(container.as_group()?)
+            .map(|(k, v)| Ok((k.to_owned(), Data::read(&v)?)))
+            .collect();
         Ok(Mapping(data?))
     }
 }
 
 impl Writable for Mapping {
-    fn write<B: Backend, G: GroupOp<B>>(&self, location: &G, name: &str) -> Result<DataContainer<B>> {
+    fn write<B: Backend, G: GroupOp<B>>(
+        &self,
+        location: &G,
+        name: &str,
+    ) -> Result<DataContainer<B>> {
         let mut group = location.new_group(name)?;
         self.metadata().save(&mut group)?;
         self.0

--- a/anndata/src/lib.rs
+++ b/anndata/src/lib.rs
@@ -1,17 +1,19 @@
 mod anndata;
-pub mod concat;
-pub mod traits;
 pub mod backend;
-pub mod data;
+pub mod concat;
 pub mod container;
-pub mod reader;
+pub mod data;
 mod macros;
+pub mod reader;
+pub mod traits;
 
-pub use traits::{AnnDataOp, AxisArraysOp, ElemCollectionOp, ArrayElemOp};
 pub use crate::anndata::{AnnData, AnnDataSet, StackedAnnData};
 pub use backend::Backend;
-pub use data::{HasShape, Data, Readable, Writable, ArrayData, WritableArray, ReadableArray, Selectable};
 pub use container::{
-    AxisArrays, DataFrameElem, Elem, ElemCollection, ArrayElem, 
-    StackedAxisArrays, StackedDataFrame, StackedArrayElem,
+    ArrayElem, AxisArrays, DataFrameElem, Elem, ElemCollection, StackedArrayElem,
+    StackedAxisArrays, StackedDataFrame,
 };
+pub use data::{
+    ArrayData, Data, HasShape, Readable, ReadableArray, Selectable, Writable, WritableArray,
+};
+pub use traits::{AnnDataOp, ArrayElemOp, AxisArraysOp, ElemCollectionOp};

--- a/anndata/src/macros.rs
+++ b/anndata/src/macros.rs
@@ -55,4 +55,4 @@ macro_rules! dyn_map_fun {
     };
 }
 
-pub(crate) use {dyn_match, dyn_map, dyn_map_fun};
+pub(crate) use {dyn_map, dyn_map_fun, dyn_match};

--- a/anndata/src/reader.rs
+++ b/anndata/src/reader.rs
@@ -1,5 +1,5 @@
 use crate::data::utils::to_csr_data;
-use crate::{data::array::DataFrameIndex, AnnDataOp, ArrayData};
+use crate::{AnnDataOp, ArrayData, data::array::DataFrameIndex};
 
 use anyhow::Result;
 use flate2::read::MultiGzDecoder;
@@ -58,16 +58,16 @@ impl MMReader {
         if self.sorted {
             let (_, cols, iter) = read_sorted_mm_body_from_bufread::<_, f64>(&mut self.reader);
             output.set_x_from_iter(
-                iter
-                    .chunk_by(|x| x.0)
+                iter.chunk_by(|x| x.0)
                     .into_iter()
                     .map(|x| x.1.map(|(_, j, v)| (j, v)).collect::<Vec<_>>())
                     .chunks(2000)
                     .into_iter()
                     .map(|x| {
-                        let (r, c, indptr, indices, data) = to_csr_data(x.into_iter().collect::<Vec<_>>(), cols);
+                        let (r, c, indptr, indices, data) =
+                            to_csr_data(x.into_iter().collect::<Vec<_>>(), cols);
                         CsrMatrix::try_from_csr_data(r, c, indptr, indices, data).unwrap()
-                    })
+                    }),
             )?;
         } else {
             output.set_x(read_matrix_market_from_bufread(&mut self.reader)?)?;
@@ -213,7 +213,7 @@ where
             line.clear();
             let len = reader.read_line(&mut line).unwrap();
             // check for an all whitespace line
-            if len != 0 && line.split_whitespace().next() == None {
+            if len != 0 && line.split_whitespace().next().is_none() {
                 continue 'empty_lines;
             }
             break;
@@ -248,10 +248,10 @@ where
             panic!("BadMatrixMarketFile");
         }
         (row, col, val)
-    }).take(entries);
+    })
+    .take(entries);
     (rows, cols, iter)
 }
-
 
 fn read_matrix_market_from_bufread<R>(reader: &mut R) -> Result<ArrayData, IoError>
 where
@@ -327,7 +327,7 @@ where
             line.clear();
             let len = reader.read_line(&mut line)?;
             // check for an all whitespace line
-            if len != 0 && line.split_whitespace().next() == None {
+            if len != 0 && line.split_whitespace().next().is_none() {
                 continue 'empty_lines;
             }
             break;

--- a/anndata/src/traits.rs
+++ b/anndata/src/traits.rs
@@ -1,15 +1,15 @@
 use std::{collections::HashMap, path::Path};
 
 use crate::{
-    anndata::elem_io::{open_layers, new_mapping, open_obsm, open_obsp, open_varm, open_varp},
+    AnnData, AnnDataSet, ArrayElem, AxisArrays, Backend, ElemCollection, StackedArrayElem,
+    StackedAxisArrays,
+    anndata::elem_io::{new_mapping, open_layers, open_obsm, open_obsp, open_varm, open_varp},
     backend::DataType,
     container::{ChunkedArrayElem, InnerDataFrameElem, StackedChunkedArrayElem},
     data::*,
-    AnnData, AnnDataSet, ArrayElem, AxisArrays, Backend, ElemCollection, StackedArrayElem,
-    StackedAxisArrays,
 };
 
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::{Context, Result, bail, ensure};
 use polars::prelude::DataFrame;
 use smallvec::SmallVec;
 
@@ -278,8 +278,14 @@ pub trait AnnDataOp {
 
 impl<T: AnnDataOp> AnnDataOp for &T {
     type X = T::X;
-    type AxisArraysRef<'a> = T::AxisArraysRef<'a> where Self: 'a;
-    type ElemCollectionRef<'a> = T::ElemCollectionRef<'a> where Self: 'a;
+    type AxisArraysRef<'a>
+        = T::AxisArraysRef<'a>
+    where
+        Self: 'a;
+    type ElemCollectionRef<'a>
+        = T::ElemCollectionRef<'a>
+    where
+        Self: 'a;
 
     fn x(&self) -> Self::X {
         (*self).x()
@@ -462,7 +468,6 @@ impl<T: AnnDataOp> AnnDataOp for &T {
     }
 }
 
-
 impl<B: Backend> AnnDataOp for AnnData<B> {
     type X = ArrayElem<B>;
     type AxisArraysRef<'a> = &'a AxisArrays<B>;
@@ -620,13 +625,13 @@ impl<B: Backend> AnnDataOp for AnnData<B> {
         self.get_obs()
             .lock()
             .as_mut()
-            .map_or(Ok(DataFrame::empty()), |x| x.data().map(Clone::clone))
+            .map_or(Ok(DataFrame::empty()), |x| x.data().cloned())
     }
     fn read_var(&self) -> Result<DataFrame> {
         self.get_var()
             .lock()
             .as_mut()
-            .map_or(Ok(DataFrame::empty()), |x| x.data().map(Clone::clone))
+            .map_or(Ok(DataFrame::empty()), |x| x.data().cloned())
     }
 
     fn set_obs(&self, obs: DataFrame) -> Result<()> {
@@ -676,9 +681,8 @@ impl<B: Backend> AnnDataOp for AnnData<B> {
     }
     fn obsm(&self) -> Self::AxisArraysRef<'_> {
         if self.obsm.is_none() {
-            let arrays = new_mapping(&self.file, "obsm").and_then(|g|
-                open_obsm(g, Some(&self.n_obs))
-            );
+            let arrays =
+                new_mapping(&self.file, "obsm").and_then(|g| open_obsm(g, Some(&self.n_obs)));
             if let Ok(obsm) = arrays {
                 self.obsm.swap(&obsm);
             }
@@ -687,9 +691,8 @@ impl<B: Backend> AnnDataOp for AnnData<B> {
     }
     fn obsp(&self) -> Self::AxisArraysRef<'_> {
         if self.obsp.is_none() {
-            let arrays = new_mapping(&self.file, "obsp").and_then(|g|
-                open_obsp(g, Some(&self.n_obs))
-            );
+            let arrays =
+                new_mapping(&self.file, "obsp").and_then(|g| open_obsp(g, Some(&self.n_obs)));
             if let Ok(obsp) = arrays {
                 self.obsp.swap(&obsp);
             }
@@ -698,9 +701,8 @@ impl<B: Backend> AnnDataOp for AnnData<B> {
     }
     fn varm(&self) -> Self::AxisArraysRef<'_> {
         if self.varm.is_none() {
-            let arrays = new_mapping(&self.file, "varm").and_then(|g|
-                open_varm(g, Some(&self.n_vars))
-            );
+            let arrays =
+                new_mapping(&self.file, "varm").and_then(|g| open_varm(g, Some(&self.n_vars)));
             if let Ok(varm) = arrays {
                 self.varm.swap(&varm);
             }
@@ -709,9 +711,8 @@ impl<B: Backend> AnnDataOp for AnnData<B> {
     }
     fn varp(&self) -> Self::AxisArraysRef<'_> {
         if self.varp.is_none() {
-            let arrays = new_mapping(&self.file, "varp").and_then(|g|
-                open_varp(g, Some(&self.n_vars))
-            );
+            let arrays =
+                new_mapping(&self.file, "varp").and_then(|g| open_varp(g, Some(&self.n_vars)));
             if let Ok(varp) = arrays {
                 self.varp.swap(&varp);
             }
@@ -720,9 +721,8 @@ impl<B: Backend> AnnDataOp for AnnData<B> {
     }
     fn layers(&self) -> Self::AxisArraysRef<'_> {
         if self.layers.is_none() {
-            let arrays = new_mapping(&self.file, "layers").and_then(|g|
-                open_layers(g, Some(&self.n_obs), Some(&self.n_vars))
-            );
+            let arrays = new_mapping(&self.file, "layers")
+                .and_then(|g| open_layers(g, Some(&self.n_obs), Some(&self.n_vars)));
             if let Ok(layers) = arrays {
                 self.layers.swap(&layers);
             }
@@ -992,7 +992,7 @@ pub trait AxisArraysOp {
         &self,
         key: &str,
         chunk_size: usize,
-    ) -> Option<<Self::ArrayElem as ArrayElemOp>::ArrayIter<D>> 
+    ) -> Option<<Self::ArrayElem as ArrayElemOp>::ArrayIter<D>>
     where
         D: TryFrom<ArrayData>,
         <D as TryFrom<ArrayData>>::Error: std::fmt::Debug,
@@ -1131,7 +1131,8 @@ pub trait ArrayElemOp {
 }
 
 impl<B: Backend> ArrayElemOp for ArrayElem<B> {
-    type ArrayIter<D> = ChunkedArrayElem<B, D>
+    type ArrayIter<D>
+        = ChunkedArrayElem<B, D>
     where
         D: TryFrom<ArrayData>,
         <D as TryFrom<ArrayData>>::Error: std::fmt::Debug;
@@ -1188,7 +1189,8 @@ impl<B: Backend> ArrayElemOp for ArrayElem<B> {
 }
 
 impl<B: Backend> ArrayElemOp for StackedArrayElem<B> {
-    type ArrayIter<D> = StackedChunkedArrayElem<B, D>
+    type ArrayIter<D>
+        = StackedChunkedArrayElem<B, D>
     where
         D: TryFrom<ArrayData>,
         <D as TryFrom<ArrayData>>::Error: std::fmt::Debug;

--- a/anndata/src/traits.rs
+++ b/anndata/src/traits.rs
@@ -201,7 +201,7 @@ pub trait AnnDataOp {
         let adatas = indices
             .into_iter()
             .map(|(key, idx)| {
-                let path = out_dir.as_ref().join(format!("{}.h5ad", key));
+                let path = out_dir.as_ref().join(format!("{key}.h5ad"));
                 let adata = AnnData::<B>::new(&path)?;
                 adata.set_n_obs(idx.len())?;
                 adata.set_n_vars(n_vars)?;
@@ -603,7 +603,7 @@ impl<B: Backend> AnnDataOp for AnnData<B> {
                 inner
                     .index
                     .get_index(i)
-                    .context(format!("'{}' does not exist in obs_names", i))
+                    .context(format!("'{i}' does not exist in obs_names"))
             })
             .collect()
     }
@@ -616,7 +616,7 @@ impl<B: Backend> AnnDataOp for AnnData<B> {
                 inner
                     .index
                     .get_index(i)
-                    .context(format!("'{}' does not exist in obs_names", i))
+                    .context(format!("'{i}' does not exist in obs_names"))
             })
             .collect()
     }
@@ -949,7 +949,7 @@ pub trait AxisArraysOp {
         self.get(key)
             .and_then(|x| x.get().transpose())
             .transpose()
-            .map_err(|e| e.context(format!("key: {}", key)))
+            .map_err(|e| e.context(format!("key: {key}")))
     }
 
     fn iter_item<D>(&self) -> impl Iterator<Item = (String, D)>

--- a/pyanndata/Cargo.toml
+++ b/pyanndata/Cargo.toml
@@ -35,3 +35,6 @@ extension-module = ["pyo3/extension-module"]
 
 [lib]
 crate-type = ["lib"]
+
+[lints]
+workspace = true

--- a/pyanndata/src/anndata.rs
+++ b/pyanndata/src/anndata.rs
@@ -7,8 +7,8 @@ pub use dataset::AnnDataSet;
 pub use memory::PyAnnData;
 
 use anndata;
-use anndata::concat::JoinType;
 use anndata::Backend;
+use anndata::concat::JoinType;
 use anndata_hdf5::H5;
 use anyhow::Result;
 use pyo3::prelude::*;
@@ -75,7 +75,7 @@ pub fn read<'py>(
 }
 
 /// Concatenates AnnData objects.
-/// 
+///
 /// When `file` is provided, this function saves the merged AnnData object on disk
 /// in a streaming fashion. This is memory efficient and allows merging large datasets
 /// that do not fit into memory.
@@ -95,13 +95,13 @@ pub fn read<'py>(
 ///     If provided, the concatenated AnnData will be saved to this file.
 /// backend: Literal['hdf5', 'zarr']
 ///     Backend to use for writing the output file.
-/// 
+///
 /// Returns
 /// -------
-/// 
+///
 /// AnnData
 ///     The concatenated AnnData object.
-/// 
+///
 /// See Also
 /// --------
 /// AnnDataSet
@@ -130,7 +130,7 @@ pub fn concat<'py>(
         Py(PyAnnData<'a>),
     }
 
-    let keys = keys.as_ref().map(|x| x.as_slice());
+    let keys = keys.as_deref();
     let out = if let Some(file) = file {
         let backend = get_backend(&file, backend);
         match backend {

--- a/pyanndata/src/anndata/backed.rs
+++ b/pyanndata/src/anndata/backed.rs
@@ -118,7 +118,7 @@ impl AnnData {
                     .map(|name| {
                         index
                             .get_index(&name)
-                            .expect(&format!("Unknown obs name: {}", name))
+                            .unwrap_or_else(|| panic!("Unknown obs name: {}", name))
                     })
                     .collect::<Vec<_>>()
             });
@@ -145,7 +145,7 @@ impl AnnData {
                     .map(|name| {
                         index
                             .get_index(&name)
-                            .expect(&format!("Unknown var name: {}", name))
+                            .unwrap_or_else(|| panic!("Unknown var name: {}", name))
                     })
                     .collect::<Vec<_>>()
             });
@@ -170,6 +170,7 @@ impl<B: Backend> From<anndata::AnnData<B>> for AnnData {
 }
 
 #[pymethods]
+#[allow(clippy::too_many_arguments)]
 impl AnnData {
     #[new]
     #[pyo3(
@@ -182,7 +183,7 @@ impl AnnData {
     )]
     pub fn new(
         filename: PathBuf,
-        X: Option<PyArrayData>,
+        #[allow(non_snake_case)] X: Option<PyArrayData>,
         obs: Option<Bound<'_, PyAny>>,
         var: Option<Bound<'_, PyAny>>,
         obsm: Option<HashMap<String, PyArrayData>>,
@@ -616,7 +617,7 @@ impl AnnData {
     /// partial : list[str] | None
     ///     A list of fields to copy. If None, copies all fields. Possible fields are:
     ///     "X", "obs", "var", "obsm", "obsp", "varm", "varp", "uns", "layers".
-
+    ///
     /// Returns
     /// -------
     /// AnnData
@@ -1160,11 +1161,7 @@ impl<B: Backend> AnnDataTrait for InnerAnnData<B> {
         py: Python<'py>,
         partial: Option<HashSet<String>>,
     ) -> Result<PyAnnData<'py>> {
-        Ok(PyAnnData::from_anndata(
-            py,
-            self.adata.inner().deref(),
-            partial,
-        )?)
+        PyAnnData::from_anndata(py, self.adata.inner().deref(), partial)
     }
 
     fn filename(&self) -> PathBuf {

--- a/pyanndata/src/anndata/backed.rs
+++ b/pyanndata/src/anndata/backed.rs
@@ -96,11 +96,11 @@ impl AnnData {
                 let file = match mode {
                     "r" => H5::open(filename)?,
                     "r+" => H5::open_rw(filename)?,
-                    _ => bail!("Unknown mode: {}", mode),
+                    _ => bail!("Unknown mode: {mode}"),
                 };
                 anndata::AnnData::<H5>::open(file).map(|adata| adata.into())
             }
-            x => bail!("Unknown backend: {}", x),
+            x => bail!("Unknown backend: {x}"),
         }
     }
 
@@ -118,7 +118,7 @@ impl AnnData {
                     .map(|name| {
                         index
                             .get_index(&name)
-                            .unwrap_or_else(|| panic!("Unknown obs name: {}", name))
+                            .unwrap_or_else(|| panic!("Unknown obs name: {name}"))
                     })
                     .collect::<Vec<_>>()
             });
@@ -145,7 +145,7 @@ impl AnnData {
                     .map(|name| {
                         index
                             .get_index(&name)
-                            .unwrap_or_else(|| panic!("Unknown var name: {}", name))
+                            .unwrap_or_else(|| panic!("Unknown var name: {name}"))
                     })
                     .collect::<Vec<_>>()
             });
@@ -194,7 +194,7 @@ impl AnnData {
         let backend = get_backend(&filename, backend);
         let adata: AnnData = match backend {
             H5::NAME => anndata::AnnData::<H5>::new(filename)?.into(),
-            backend => bail!("Unknown backend: {}", backend),
+            backend => bail!("Unknown backend: {backend}"),
         };
 
         if X.is_some() {
@@ -995,7 +995,7 @@ impl<B: Backend> AnnDataTrait for InnerAnnData<B> {
                             .into_any(),
                     ))
                 }
-                x => bail!("Unsupported backend: {}", x),
+                x => bail!("Unsupported backend: {x}"),
             }
         } else {
             let adata = PyAnnData::new(py)?;
@@ -1141,7 +1141,7 @@ impl<B: Backend> AnnDataTrait for InnerAnnData<B> {
                 .adata
                 .inner()
                 .write::<H5, _>(filename, partial, chunk_size),
-            x => bail!("Unsupported backend: {}", x),
+            x => bail!("Unsupported backend: {x}"),
         }
     }
 
@@ -1189,7 +1189,7 @@ impl<B: Backend> AnnDataTrait for InnerAnnData<B> {
             let file = match mode {
                 "r" => B::open(self.filename())?,
                 "r+" => B::open_rw(self.filename())?,
-                _ => bail!("Unknown mode: {}", mode),
+                _ => bail!("Unknown mode: {mode}"),
             };
             self.adata.insert(anndata::AnnData::<B>::open(file)?);
         }

--- a/pyanndata/src/anndata/dataset.rs
+++ b/pyanndata/src/anndata/dataset.rs
@@ -1,7 +1,7 @@
 use crate::container::{
     PyArrayElem, PyAxisArrays, PyChunkedArray, PyDataFrameElem, PyElemCollection,
 };
-use crate::data::{isinstance_of_pandas, to_select_elem, PyArrayData, PyData};
+use crate::data::{PyArrayData, PyData, isinstance_of_pandas, to_select_elem};
 use crate::{AnnData, PyAnnData};
 
 use anndata::container::Slot;
@@ -10,8 +10,8 @@ use anndata::{self, ArrayElemOp, Data, Selectable};
 use anndata::{AnnDataOp, Backend};
 use anndata::{AxisArraysOp, ElemCollectionOp};
 use anndata_hdf5::H5;
-use anyhow::{bail, Result};
-use downcast_rs::{impl_downcast, Downcast};
+use anyhow::{Result, bail};
+use downcast_rs::{Downcast, impl_downcast};
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
 use std::collections::HashMap;
@@ -96,7 +96,7 @@ impl AnnDataSet {
                     .map(|name| {
                         index
                             .get_index(&name)
-                            .expect(&format!("Unknown obs name: {}", name))
+                            .unwrap_or_else(|| panic!("Unknown obs name: {}", name))
                     })
                     .collect::<Vec<_>>()
             });
@@ -123,7 +123,7 @@ impl AnnDataSet {
                     .map(|name| {
                         index
                             .get_index(&name)
-                            .expect(&format!("Unknown obs name: {}", name))
+                            .unwrap_or_else(|| panic!("Unknown obs name: {}", name))
                     })
                     .collect::<Vec<_>>()
             });
@@ -166,7 +166,10 @@ impl AnnDataSet {
                     };
                     (key, adata)
                 });
-                Ok(anndata::AnnDataSet::new(anndatas, filename, add_key, use_absolute_path)?.into())
+                Ok(
+                    anndata::AnnDataSet::new(anndatas, filename, add_key, use_absolute_path)?
+                        .into(),
+                )
             }
             _ => todo!(),
         }
@@ -442,8 +445,8 @@ impl AnnDataSet {
     }
 }
 
-/// Lazily concatenated AnnData objects.
 /*
+/// Lazily concatenated AnnData objects.
 #[pyclass]
 #[repr(transparent)]
 pub struct StackedAnnData(pub Slot<anndata::StackedAnnData>);

--- a/pyanndata/src/anndata/dataset.rs
+++ b/pyanndata/src/anndata/dataset.rs
@@ -96,7 +96,7 @@ impl AnnDataSet {
                     .map(|name| {
                         index
                             .get_index(&name)
-                            .unwrap_or_else(|| panic!("Unknown obs name: {}", name))
+                            .unwrap_or_else(|| panic!("Unknown obs name: {name}"))
                     })
                     .collect::<Vec<_>>()
             });
@@ -123,7 +123,7 @@ impl AnnDataSet {
                     .map(|name| {
                         index
                             .get_index(&name)
-                            .unwrap_or_else(|| panic!("Unknown obs name: {}", name))
+                            .unwrap_or_else(|| panic!("Unknown obs name: {name}"))
                     })
                     .collect::<Vec<_>>()
             });
@@ -715,7 +715,7 @@ impl<B: Backend> AnnDataSetTrait for Slot<anndata::AnnDataSet<B>> {
                     let adata = inner.to_adata_select::<H5, _, _>(slice, file, copy_x)?;
                     Ok(AnnData::from(adata).into_pyobject(py)?.into_any())
                 }
-                x => bail!("Unsupported backend: {}", x),
+                x => bail!("Unsupported backend: {x}"),
             }
         } else {
             let adata = PyAnnData::new(py)?;
@@ -844,7 +844,7 @@ impl<B: Backend> AnnDataSetTrait for Slot<anndata::AnnDataSet<B>> {
         if self.is_none() {
             "Closed AnnDataSet object".to_string()
         } else {
-            format!("{}", self)
+            format!("{self}")
         }
     }
 

--- a/pyanndata/src/anndata/memory.rs
+++ b/pyanndata/src/anndata/memory.rs
@@ -604,7 +604,7 @@ impl ArrayElemOp for ArrayElem<'_> {
 
     fn dtype(&self) -> Option<anndata::backend::DataType> {
         let dtype: Option<String> = self.0.getattr("dtype").unwrap().extract().unwrap();
-        panic!("{:?}", dtype);
+        panic!("{dtype:?}");
     }
 
     fn shape(&self) -> Option<Shape> {

--- a/pyanndata/src/anndata/memory.rs
+++ b/pyanndata/src/anndata/memory.rs
@@ -1,16 +1,16 @@
-use crate::data::{isinstance_of_pyanndata, isinstance_of_polars, PyArrayData, PyData};
+use crate::data::{PyArrayData, PyData, isinstance_of_polars, isinstance_of_pyanndata};
 
-use std::collections::HashSet;
-use std::ops::Deref;
+use anndata::data::{ArrayChunk, DataFrameIndex, SelectInfoElem, Shape, Stackable};
+use anndata::{self, ArrayElemOp, ElemCollectionOp, Selectable};
+use anndata::{AnnDataOp, ArrayData, AxisArraysOp, Backend, Data, HasShape};
+use anyhow::{Result, bail};
 use polars::prelude::DataFrame;
-use pyo3::prelude::*;
 use pyo3::exceptions::PyTypeError;
+use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
 use pyo3_polars::PyDataFrame;
-use anndata::{self, Selectable, ElemCollectionOp, ArrayElemOp};
-use anndata::{AnnDataOp, AxisArraysOp, ArrayData, Data, Backend, HasShape};
-use anndata::data::{ArrayChunk, DataFrameIndex, SelectInfoElem, Shape, Stackable};
-use anyhow::{Result, bail};
+use std::collections::HashSet;
+use std::ops::Deref;
 
 pub struct PyAnnData<'py>(Bound<'py, PyAny>);
 
@@ -51,16 +51,20 @@ impl<'py> PyAnnData<'py> {
             .extract()
     }
 
-    pub fn from_anndata<B: Backend>(py: Python<'py>, inner: &anndata::AnnData<B>, partial: Option<HashSet<String>>) -> Result<Self> {
+    pub fn from_anndata<B: Backend>(
+        py: Python<'py>,
+        inner: &anndata::AnnData<B>,
+        partial: Option<HashSet<String>>,
+    ) -> Result<Self> {
         let partial = partial.unwrap_or_default();
         let adata = PyAnnData::new(py)?;
         adata.set_n_obs(inner.n_obs())?;
         adata.set_n_vars(inner.n_vars())?;
 
-        if partial.is_empty() || partial.contains("X") {
-            if let Some(x) = inner.x().get::<ArrayData>()? {
-                adata.set_x(x)?;
-            }
+        if (partial.is_empty() || partial.contains("X"))
+            && let Some(x) = inner.x().get::<ArrayData>()?
+        {
+            adata.set_x(x)?;
         }
 
         if partial.is_empty() || partial.contains("obs") {
@@ -74,45 +78,51 @@ impl<'py> PyAnnData<'py> {
         }
 
         if partial.is_empty() || partial.contains("uns") {
-            inner
-                .uns().keys()
-                .into_iter()
-                .try_for_each(|k| adata.uns().add(&k, inner.uns().get_item::<Data>(&k)?.unwrap()))?;
+            inner.uns().keys().into_iter().try_for_each(|k| {
+                adata
+                    .uns()
+                    .add(&k, inner.uns().get_item::<Data>(&k)?.unwrap())
+            })?;
         }
 
         if partial.is_empty() || partial.contains("obsm") {
-            inner
-                .obsm().keys()
-                .into_iter()
-                .try_for_each(|k| adata.obsm().add(&k, inner.obsm().get_item::<ArrayData>(&k)?.unwrap()))?;
+            inner.obsm().keys().into_iter().try_for_each(|k| {
+                adata
+                    .obsm()
+                    .add(&k, inner.obsm().get_item::<ArrayData>(&k)?.unwrap())
+            })?;
         }
 
         if partial.is_empty() || partial.contains("obsp") {
-            inner
-                .obsp().keys()
-                .into_iter()
-                .try_for_each(|k| adata.obsp().add(&k, inner.obsp().get_item::<ArrayData>(&k)?.unwrap()))?;
+            inner.obsp().keys().into_iter().try_for_each(|k| {
+                adata
+                    .obsp()
+                    .add(&k, inner.obsp().get_item::<ArrayData>(&k)?.unwrap())
+            })?;
         }
 
         if partial.is_empty() || partial.contains("varm") {
-            inner
-                .varm().keys()
-                .into_iter()
-                .try_for_each(|k| adata.varm().add(&k, inner.varm().get_item::<ArrayData>(&k)?.unwrap()))?;
+            inner.varm().keys().into_iter().try_for_each(|k| {
+                adata
+                    .varm()
+                    .add(&k, inner.varm().get_item::<ArrayData>(&k)?.unwrap())
+            })?;
         }
 
         if partial.is_empty() || partial.contains("varp") {
-            inner
-                .varp().keys()
-                .into_iter()
-                .try_for_each(|k| adata.varp().add(&k, inner.varp().get_item::<ArrayData>(&k)?.unwrap()))?;
+            inner.varp().keys().into_iter().try_for_each(|k| {
+                adata
+                    .varp()
+                    .add(&k, inner.varp().get_item::<ArrayData>(&k)?.unwrap())
+            })?;
         }
 
         if partial.is_empty() || partial.contains("layers") {
-            inner
-                .layers().keys()
-                .into_iter()
-                .try_for_each(|k| adata.layers().add(&k, inner.layers().get_item::<ArrayData>(&k)?.unwrap()))?;
+            inner.layers().keys().into_iter().try_for_each(|k| {
+                adata
+                    .layers()
+                    .add(&k, inner.layers().get_item::<ArrayData>(&k)?.unwrap())
+            })?;
         }
 
         Ok(adata)
@@ -121,8 +131,14 @@ impl<'py> PyAnnData<'py> {
 
 impl<'py> AnnDataOp for PyAnnData<'py> {
     type X = ArrayElem<'py>;
-    type ElemCollectionRef<'a> = ElemCollection<'a> where Self: 'a;
-    type AxisArraysRef<'a> = AxisArrays<'a> where Self: 'a;
+    type ElemCollectionRef<'a>
+        = ElemCollection<'a>
+    where
+        Self: 'a;
+    type AxisArraysRef<'a>
+        = AxisArrays<'a>
+    where
+        Self: 'a;
 
     fn x(&self) -> Self::X {
         ArrayElem(self.0.getattr("X").unwrap())
@@ -146,7 +162,7 @@ impl<'py> AnnDataOp for PyAnnData<'py> {
         let shape = data.shape();
         self.set_n_obs(shape[0])?;
         self.set_n_vars(shape[1])?;
-        let ob: ArrayData = data.into();
+        let ob: ArrayData = data;
         self.setattr("X", PyArrayData::from(ob))?;
         Ok(())
     }
@@ -198,14 +214,30 @@ impl<'py> AnnDataOp for PyAnnData<'py> {
     }
 
     fn obs_names(&self) -> DataFrameIndex {
-        self.0.getattr("obs_names").unwrap().extract::<Vec<String>>().unwrap().into()
+        self.0
+            .getattr("obs_names")
+            .unwrap()
+            .extract::<Vec<String>>()
+            .unwrap()
+            .into()
     }
     fn var_names(&self) -> DataFrameIndex {
-        self.0.getattr("var_names").unwrap().extract::<Vec<String>>().unwrap().into()
+        self.0
+            .getattr("var_names")
+            .unwrap()
+            .extract::<Vec<String>>()
+            .unwrap()
+            .into()
     }
 
     fn set_obs_names(&self, index: DataFrameIndex) -> Result<()> {
-        if self.getattr("obs")?.getattr("empty")?.cast().unwrap().is_true() {
+        if self
+            .getattr("obs")?
+            .getattr("empty")?
+            .cast()
+            .unwrap()
+            .is_true()
+        {
             let py = self.py();
             let df = py.import("pandas")?.call_method(
                 "DataFrame",
@@ -219,7 +251,13 @@ impl<'py> AnnDataOp for PyAnnData<'py> {
         Ok(())
     }
     fn set_var_names(&self, index: DataFrameIndex) -> Result<()> {
-        if self.getattr("var")?.getattr("empty")?.cast().unwrap().is_true() {
+        if self
+            .getattr("var")?
+            .getattr("empty")?
+            .cast()
+            .unwrap()
+            .is_true()
+        {
             let py = self.py();
             let df = py.import("pandas")?.call_method(
                 "DataFrame",
@@ -233,18 +271,24 @@ impl<'py> AnnDataOp for PyAnnData<'py> {
         Ok(())
     }
 
-    fn obs_ix<'a, I: IntoIterator<Item = &'a str>>(&self, _names: I) -> Result<Vec<usize>> {todo!()}
-    fn var_ix<'a, I: IntoIterator<Item = &'a str>>(&self, _names: I) -> Result<Vec<usize>> {todo!()}
+    fn obs_ix<'a, I: IntoIterator<Item = &'a str>>(&self, _names: I) -> Result<Vec<usize>> {
+        todo!()
+    }
+    fn var_ix<'a, I: IntoIterator<Item = &'a str>>(&self, _names: I) -> Result<Vec<usize>> {
+        todo!()
+    }
 
     fn read_obs(&self) -> Result<DataFrame> {
-        let df: PyDataFrame = self.py()
+        let df: PyDataFrame = self
+            .py()
             .import("polars")?
             .call_method1("from_pandas", (self.0.getattr("obs")?,))?
             .extract()?;
         Ok(df.into())
     }
     fn read_var(&self) -> Result<DataFrame> {
-        let df: PyDataFrame = self.py()
+        let df: PyDataFrame = self
+            .py()
             .import("polars")?
             .call_method1("from_pandas", (self.0.getattr("var")?,))?
             .extract()?;
@@ -255,7 +299,8 @@ impl<'py> AnnDataOp for PyAnnData<'py> {
         let py = self.py();
         let is_empty = obs.height() == 0 || obs.width() == 0;
         let index = self.getattr("obs")?.getattr("index")?;
-        let mut df = PyDataFrame(obs).into_pyobject(py)?
+        let mut df = PyDataFrame(obs)
+            .into_pyobject(py)?
             .call_method0("to_pandas")?;
 
         if is_empty {
@@ -272,7 +317,8 @@ impl<'py> AnnDataOp for PyAnnData<'py> {
         let py = self.py();
         let is_empty = var.height() == 0 || var.width() == 0;
         let index = self.getattr("var")?.getattr("index")?;
-        let mut df = PyDataFrame(var).into_pyobject(py)?
+        let mut df = PyDataFrame(var)
+            .into_pyobject(py)?
             .call_method0("to_pandas")?;
 
         if is_empty {
@@ -415,7 +461,7 @@ where
 {
     fn len(&self) -> usize {
         let n = self.total_rows / self.chunk_size;
-        if self.total_rows % self.chunk_size == 0 {
+        if self.total_rows.is_multiple_of(self.chunk_size) {
             n
         } else {
             n + 1
@@ -427,26 +473,31 @@ pub struct ElemCollection<'a>(Bound<'a, PyAny>);
 
 impl ElemCollectionOp for ElemCollection<'_> {
     fn keys(&self) -> Vec<String> {
-        self.0.call_method0("keys").unwrap().try_iter().unwrap().map(|x| x.unwrap().extract().unwrap()).collect()
+        self.0
+            .call_method0("keys")
+            .unwrap()
+            .try_iter()
+            .unwrap()
+            .map(|x| x.unwrap().extract().unwrap())
+            .collect()
     }
 
     fn get_item<D>(&self, key: &str) -> Result<Option<D>>
-        where
-            D: TryFrom<Data>,
-            <D as TryFrom<Data>>::Error: Into<anyhow::Error>
+    where
+        D: TryFrom<Data>,
+        <D as TryFrom<Data>>::Error: Into<anyhow::Error>,
     {
-        self.0.call_method1("__getitem__", (key,)).ok().map(|x| {
-            let data: Data = x.extract::<PyData>()?.into();
-            data.try_into().map_err(Into::into)
-        }).transpose()
+        self.0
+            .call_method1("__getitem__", (key,))
+            .ok()
+            .map(|x| {
+                let data: Data = x.extract::<PyData>()?.into();
+                data.try_into().map_err(Into::into)
+            })
+            .transpose()
     }
 
-    fn add<D: Into<Data>>(
-            &self,
-            key: &str,
-            data: D,
-        ) -> Result<()>
-    {
+    fn add<D: Into<Data>>(&self, key: &str, data: D) -> Result<()> {
         let py = self.0.py();
         let d = PyData::from(data.into()).into_pyobject(py)?.into_any();
         let new_d = if isinstance_of_polars(&d)? {
@@ -474,19 +525,23 @@ impl<'py> AxisArraysOp for AxisArrays<'py> {
     type ArrayElem = ArrayElem<'py>;
 
     fn keys(&self) -> Vec<String> {
-        self.arrays.call_method0("keys").unwrap().try_iter().unwrap().map(|x| x.unwrap().extract().unwrap()).collect()
+        self.arrays
+            .call_method0("keys")
+            .unwrap()
+            .try_iter()
+            .unwrap()
+            .map(|x| x.unwrap().extract().unwrap())
+            .collect()
     }
 
     fn get(&self, key: &str) -> Option<Self::ArrayElem> {
-        self.arrays.call_method1("__getitem__", (key,)).ok().map(ArrayElem)
+        self.arrays
+            .call_method1("__getitem__", (key,))
+            .ok()
+            .map(ArrayElem)
     }
 
-    fn add<D: Into<ArrayData>>(
-            &self,
-            key: &str,
-            data: D,
-        ) -> Result<()>
-    {
+    fn add<D: Into<ArrayData>>(&self, key: &str, data: D) -> Result<()> {
         let data = data.into();
         let py = self.arrays.py();
         let shape = data.shape();
@@ -509,9 +564,9 @@ impl<'py> AxisArraysOp for AxisArrays<'py> {
     }
 
     fn add_iter<I, D>(&self, key: &str, data: I) -> Result<()>
-        where
-            I: Iterator<Item = D>,
-            D: ArrayChunk + Into<ArrayData>,
+    where
+        I: Iterator<Item = D>,
+        D: ArrayChunk + Into<ArrayData>,
     {
         let array = Stackable::vstack(data.map(|x| x.into()))?;
         let shape = array.shape();
@@ -532,13 +587,13 @@ impl<'py> AxisArraysOp for AxisArrays<'py> {
         self.arrays.call_method1("__delitem__", (key,))?;
         Ok(())
     }
-
 }
 
 pub struct ArrayElem<'a>(Bound<'a, PyAny>);
 
 impl ArrayElemOp for ArrayElem<'_> {
-    type ArrayIter<D> = PyArrayIterator<D>
+    type ArrayIter<D>
+        = PyArrayIterator<D>
     where
         D: TryFrom<ArrayData>,
         <D as TryFrom<ArrayData>>::Error: std::fmt::Debug;
@@ -570,19 +625,19 @@ impl ArrayElemOp for ArrayElem<'_> {
     where
         D: TryFrom<ArrayData>,
         S: AsRef<[SelectInfoElem]>,
-        <D as TryFrom<ArrayData>>::Error: Into<anyhow::Error>
+        <D as TryFrom<ArrayData>>::Error: Into<anyhow::Error>,
     {
         if let Some(data) = self.get::<ArrayData>()? {
-            data.select(slice.as_ref()).try_into().map_err(Into::into).map(Some)
+            data.select(slice.as_ref())
+                .try_into()
+                .map_err(Into::into)
+                .map(Some)
         } else {
             Ok(None)
         }
     }
 
-    fn iter<D>(
-        &self,
-        chunk_size: usize,
-    ) -> Self::ArrayIter<D>
+    fn iter<D>(&self, chunk_size: usize) -> Self::ArrayIter<D>
     where
         D: TryFrom<ArrayData>,
         <D as TryFrom<ArrayData>>::Error: std::fmt::Debug,

--- a/pyanndata/src/config.rs
+++ b/pyanndata/src/config.rs
@@ -14,7 +14,7 @@ impl PyCompression {
     /// Create a Gzip compression with the specified level (1-9)
     #[staticmethod]
     fn gzip(level: u8) -> PyResult<Self> {
-        if level < 1 || level > 9 {
+        if !(1..=9).contains(&level) {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "Gzip compression level must be between 1 and 9",
             ));
@@ -27,7 +27,7 @@ impl PyCompression {
     /// Create a Zstandard compression with the specified level (1-22)
     #[staticmethod]
     fn zstd(level: u8) -> PyResult<Self> {
-        if level < 1 || level > 22 {
+        if !(1..=22).contains(&level) {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "Zstd compression level must be between 1 and 22",
             ));
@@ -50,17 +50,17 @@ impl PyCompression {
 }
 
 /// Set the default write configuration for all subsequent write operations.
-/// 
+///
 /// This configuration is stored in thread-local storage and applies to all
 /// dataset write operations that don't explicitly specify a configuration.
-/// 
+///
 /// Parameters
 /// ----------
 /// config : dict, optional
 ///     Dictionary with optional keys:
 ///     - "compression": Compression or None
 ///     - "block_size": list of int or None
-/// 
+///
 /// Examples
 /// --------
 /// >>> import anndata_rs
@@ -91,14 +91,14 @@ pub fn py_set_default_write_config(config: Bound<'_, PyDict>) -> PyResult<()> {
 }
 
 /// Get the current default write configuration.
-/// 
+///
 /// Returns the thread-local default configuration used for dataset writes.
-/// 
+///
 /// Returns
 /// -------
 /// dict
 ///     Dictionary with keys "compression" and "block_size".
-/// 
+///
 /// Examples
 /// --------
 /// >>> import anndata_rs

--- a/pyanndata/src/config.rs
+++ b/pyanndata/src/config.rs
@@ -43,8 +43,8 @@ impl PyCompression {
 
     fn __repr__(&self) -> String {
         match self.inner {
-            Compression::Gzip(level) => format!("Compression.gzip({})", level),
-            Compression::Zst(level) => format!("Compression.zstd({})", level),
+            Compression::Gzip(level) => format!("Compression.gzip({level})"),
+            Compression::Zst(level) => format!("Compression.zstd({level})"),
         }
     }
 }

--- a/pyanndata/src/container.rs
+++ b/pyanndata/src/container.rs
@@ -1,14 +1,13 @@
 mod traits;
 
-use crate::data::{PyData, PyArrayData};
+use crate::data::{PyArrayData, PyData};
 
+use anyhow::Result;
 use pyo3::prelude::*;
 use pyo3_polars::PySeries;
-use traits::{ElemTrait, ArrayElemTrait, DataFrameElemTrait, AxisArrayTrait};
-use anyhow::Result;
+use traits::{ArrayElemTrait, AxisArrayTrait, DataFrameElemTrait, ElemTrait};
 
-use self::traits::{ElemCollectionTrait, ChunkedArrayTrait};
-
+use self::traits::{ChunkedArrayTrait, ElemCollectionTrait};
 
 #[pyclass]
 #[repr(transparent)]
@@ -103,12 +102,7 @@ impl PyArrayElem {
         signature = (size, replace=true, seed=2022),
         text_signature = "($self, size, replace=True, seed=2022)",
     )]
-    fn chunk(
-        &self,
-        size: usize,
-        replace: bool,
-        seed: u64,
-    ) -> Result<PyArrayData> {
+    fn chunk(&self, size: usize, replace: bool, seed: u64) -> Result<PyArrayData> {
         self.0.chunk(size, replace, seed).map(PyArrayData::from)
     }
 
@@ -154,7 +148,11 @@ impl PyDataFrameElem {
     }
 
     fn __setitem__(&self, key: &str, data: &Bound<'_, PyAny>) -> Result<()> {
-        let data: PySeries = data.py().import("polars")?.call_method1("Series", (data, ))?.extract()?;
+        let data: PySeries = data
+            .py()
+            .import("polars")?
+            .call_method1("Series", (data,))?
+            .extract()?;
         self.0.set(key, data.into())
     }
 
@@ -305,7 +303,6 @@ impl PyElemCollection {
     }
 }
 
-
 #[pyclass]
 #[repr(transparent)]
 pub struct PyChunkedArray(Box<dyn ChunkedArrayTrait>);
@@ -321,7 +318,9 @@ impl PyChunkedArray {
     }
 
     fn __next__(mut slf: PyRefMut<Self>) -> Option<(PyArrayData, usize, usize)> {
-        slf.0.next().map(|(data, start, end)| (data.into(), start, end))
+        slf.0
+            .next()
+            .map(|(data, start, end)| (data.into(), start, end))
     }
 }
 

--- a/pyanndata/src/container/traits.rs
+++ b/pyanndata/src/container/traits.rs
@@ -53,7 +53,7 @@ impl<B: Backend> ElemTrait for Elem<B> {
     }
 
     fn show(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 }
 
@@ -86,7 +86,7 @@ impl<B: Backend + 'static> ArrayElemTrait for ArrayElem<B> {
     }
 
     fn show(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 
     fn shape(&self) -> Vec<usize> {
@@ -127,7 +127,7 @@ impl<B: Backend + 'static> ArrayElemTrait for StackedArrayElem<B> {
     }
 
     fn show(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 
     fn shape(&self) -> Vec<usize> {
@@ -191,7 +191,7 @@ impl<B: Backend> DataFrameElemTrait for DataFrameElem<B> {
     }
 
     fn show(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 }
 
@@ -219,7 +219,7 @@ impl<B: Backend> DataFrameElemTrait for StackedDataFrame<B> {
     }
 
     fn show(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 }
 
@@ -245,7 +245,7 @@ impl<B: Backend + 'static> AxisArrayTrait for AxisArrays<B> {
         Ok(self
             .inner()
             .get(key)
-            .context(format!("No such key: {}", key))?
+            .context(format!("No such key: {key}"))?
             .inner()
             .data()?
             .into())
@@ -255,7 +255,7 @@ impl<B: Backend + 'static> AxisArrayTrait for AxisArrays<B> {
         Ok(self
             .inner()
             .get(key)
-            .context(format!("No such key: {}", key))?
+            .context(format!("No such key: {key}"))?
             .clone()
             .into())
     }
@@ -265,7 +265,7 @@ impl<B: Backend + 'static> AxisArrayTrait for AxisArrays<B> {
     }
 
     fn show(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 }
 
@@ -282,7 +282,7 @@ impl<B: Backend + 'static> AxisArrayTrait for StackedAxisArrays<B> {
         Ok(self
             .deref()
             .get(key)
-            .context(format!("No such key: {}", key))?
+            .context(format!("No such key: {key}"))?
             .data::<ArrayData>()?
             .unwrap()
             .into())
@@ -292,7 +292,7 @@ impl<B: Backend + 'static> AxisArrayTrait for StackedAxisArrays<B> {
         Ok(self
             .deref()
             .get(key)
-            .context(format!("No such key: {}", key))?
+            .context(format!("No such key: {key}"))?
             .clone()
             .into())
     }
@@ -302,7 +302,7 @@ impl<B: Backend + 'static> AxisArrayTrait for StackedAxisArrays<B> {
     }
 
     fn show(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 }
 
@@ -328,7 +328,7 @@ impl<B: Backend + 'static> ElemCollectionTrait for ElemCollection<B> {
         Ok(self
             .inner()
             .get(key)
-            .context(format!("No such key: {}", key))?
+            .context(format!("No such key: {key}"))?
             .inner()
             .data()?
             .into())
@@ -338,7 +338,7 @@ impl<B: Backend + 'static> ElemCollectionTrait for ElemCollection<B> {
         Ok(self
             .inner()
             .get(key)
-            .context(format!("No such key: {}", key))?
+            .context(format!("No such key: {key}"))?
             .clone()
             .into())
     }
@@ -348,7 +348,7 @@ impl<B: Backend + 'static> ElemCollectionTrait for ElemCollection<B> {
     }
 
     fn show(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 }
 

--- a/pyanndata/src/container/traits.rs
+++ b/pyanndata/src/container/traits.rs
@@ -1,24 +1,22 @@
 use std::ops::Deref;
 
-use crate::data::{
-    is_none_slice, to_select_info, PyArrayData, PyData,
-};
+use crate::data::{PyArrayData, PyData, is_none_slice, to_select_info};
 
 use anndata::backend::DataType;
+use anndata::container::{ChunkedArrayElem, StackedChunkedArrayElem};
 use anndata::data::SelectInfoElem;
 use anndata::{
-    ArrayData, ArrayElem, AxisArrays, Backend,
-    DataFrameElem, Elem, ElemCollection, StackedArrayElem, StackedDataFrame, StackedAxisArrays,
+    ArrayData, ArrayElem, AxisArrays, Backend, DataFrameElem, Elem, ElemCollection,
+    StackedArrayElem, StackedAxisArrays, StackedDataFrame,
 };
-use anndata::container::{ChunkedArrayElem, StackedChunkedArrayElem};
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use polars::series::Series;
 use pyo3::prelude::*;
-use pyo3_polars::{PySeries, PyDataFrame};
+use pyo3_polars::{PyDataFrame, PySeries};
 use rand::Rng;
 use rand::SeedableRng;
 
-use super::{PyArrayElem, PyElem, PyChunkedArray};
+use super::{PyArrayElem, PyChunkedArray, PyElem};
 
 /// Trait for `Elem` to abtract over different backends.
 pub trait ElemTrait: Send + Sync {
@@ -31,18 +29,19 @@ pub trait ElemTrait: Send + Sync {
 
 impl<B: Backend> ElemTrait for Elem<B> {
     fn enable_cache(&self) {
-        self.lock().as_mut().map(|x| x.enable_cache());
+        if let Some(x) = self.lock().as_mut() {
+            x.enable_cache()
+        }
     }
 
     fn disable_cache(&self) {
-        self.lock().as_mut().map(|x| x.disable_cache());
+        if let Some(x) = self.lock().as_mut() {
+            x.disable_cache()
+        }
     }
 
     fn is_scalar(&self) -> bool {
-        match self.inner().dtype() {
-            DataType::Scalar(_) => true,
-            _ => false,
-        }
+        matches!(self.inner().dtype(), DataType::Scalar(_))
     }
 
     fn get<'py>(&self, slice: &Bound<'py, PyAny>) -> Result<PyData> {
@@ -64,29 +63,26 @@ pub trait ArrayElemTrait: Send + Sync {
     fn show(&self) -> String;
     fn get(&self, subscript: &Bound<'_, PyAny>) -> Result<PyArrayData>;
     fn shape(&self) -> Vec<usize>;
-    fn chunk(
-        &self,
-        size: usize,
-        replace: bool,
-        seed: u64,
-    ) -> Result<ArrayData>;
+    fn chunk(&self, size: usize, replace: bool, seed: u64) -> Result<ArrayData>;
     fn chunked(&self, chunk_size: usize) -> PyChunkedArray;
 }
 
 impl<B: Backend + 'static> ArrayElemTrait for ArrayElem<B> {
     fn enable_cache(&self) {
-        self.lock().as_mut().map(|x| x.enable_cache());
+        if let Some(x) = self.lock().as_mut() {
+            x.enable_cache()
+        }
     }
 
     fn disable_cache(&self) {
-        self.lock().as_mut().map(|x| x.disable_cache());
+        if let Some(x) = self.lock().as_mut() {
+            x.disable_cache()
+        }
     }
 
     fn get(&self, subscript: &Bound<'_, PyAny>) -> Result<PyArrayData> {
         let slice = to_select_info(subscript, self.inner().shape())?;
-        self.inner()
-            .select::<_>(slice.as_ref())
-            .map(|x| x.into())
+        self.inner().select::<_>(slice.as_ref()).map(|x| x.into())
     }
 
     fn show(&self) -> String {
@@ -97,12 +93,7 @@ impl<B: Backend + 'static> ArrayElemTrait for ArrayElem<B> {
         self.inner().shape().as_ref().to_vec()
     }
 
-    fn chunk(
-        &self,
-        size: usize,
-        replace: bool,
-        seed: u64,
-    ) -> Result<ArrayData> {
+    fn chunk(&self, size: usize, replace: bool, seed: u64) -> Result<ArrayData> {
         let length = self.shape()[0];
         let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
         let idx: Vec<usize> = if replace {
@@ -143,12 +134,7 @@ impl<B: Backend + 'static> ArrayElemTrait for StackedArrayElem<B> {
         self.deref().shape().as_ref().unwrap().as_ref().to_vec()
     }
 
-    fn chunk(
-        &self,
-        size: usize,
-        replace: bool,
-        seed: u64,
-    ) -> Result<ArrayData> {
+    fn chunk(&self, size: usize, replace: bool, seed: u64) -> Result<ArrayData> {
         let length = self.shape()[0];
         let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
         let idx: Vec<usize> = if replace {
@@ -178,7 +164,10 @@ impl<B: Backend> DataFrameElemTrait for DataFrameElem<B> {
     fn get<'py>(&self, subscript: &Bound<'py, PyAny>) -> Result<Bound<'py, PyAny>> {
         let py = subscript.py();
         if let Ok(key) = subscript.extract::<&str>() {
-            Ok(PySeries(self.inner().column(key)?.clone().take_materialized_series()).into_pyobject(py)?)
+            Ok(
+                PySeries(self.inner().column(key)?.clone().take_materialized_series())
+                    .into_pyobject(py)?,
+            )
         } else {
             let width = self.inner().width();
             let height = self.inner().height();
@@ -294,7 +283,8 @@ impl<B: Backend + 'static> AxisArrayTrait for StackedAxisArrays<B> {
             .deref()
             .get(key)
             .context(format!("No such key: {}", key))?
-            .data::<ArrayData>()?.unwrap()
+            .data::<ArrayData>()?
+            .unwrap()
             .into())
     }
 
@@ -315,8 +305,6 @@ impl<B: Backend + 'static> AxisArrayTrait for StackedAxisArrays<B> {
         format!("{}", self)
     }
 }
-
-
 
 pub trait ElemCollectionTrait: Send + Sync {
     fn keys(&self) -> Vec<String>;
@@ -364,7 +352,10 @@ impl<B: Backend + 'static> ElemCollectionTrait for ElemCollection<B> {
     }
 }
 
-pub trait ChunkedArrayTrait: ExactSizeIterator<Item = (ArrayData, usize, usize)> + Send + Sync {}
+pub trait ChunkedArrayTrait:
+    ExactSizeIterator<Item = (ArrayData, usize, usize)> + Send + Sync
+{
+}
 
 impl<B: Backend> ChunkedArrayTrait for ChunkedArrayElem<B, ArrayData> {}
 impl<B: Backend> ChunkedArrayTrait for StackedChunkedArrayElem<B, ArrayData> {}

--- a/pyanndata/src/data.rs
+++ b/pyanndata/src/data.rs
@@ -1,14 +1,14 @@
+mod array;
 mod instance;
 mod slice;
-mod array;
 
 pub(crate) use instance::*;
 use pyo3_polars::PyDataFrame;
-pub use slice::{to_select_info, to_select_elem};
+pub use slice::{to_select_elem, to_select_info};
 
-use std::{collections::HashMap, ops::Deref};
+use anndata::data::{ArrayData, Data, DynScalar, Mapping};
 use pyo3::{prelude::*, types::PyDict};
-use anndata::data::{Data, ArrayData, DynScalar, Mapping};
+use std::{collections::HashMap, ops::Deref};
 
 pub struct PyArrayData(ArrayData);
 
@@ -26,9 +26,9 @@ impl From<ArrayData> for PyArrayData {
     }
 }
 
-impl Into<ArrayData> for PyArrayData {
-    fn into(self) -> ArrayData {
-        self.0
+impl From<PyArrayData> for ArrayData {
+    fn from(val: PyArrayData) -> Self {
+        val.0
     }
 }
 
@@ -47,14 +47,18 @@ impl FromPyObject<'_, '_> for PyArrayData {
         } else if isinstance_of_csc(&ob)? {
             Ok(ArrayData::from(array::to_csc(&ob)?).into())
         } else if isinstance_of_pandas(&ob)? {
-            let ob = ob.py().import("polars")?.call_method1("from_pandas", (ob, ))?;
+            let ob = ob
+                .py()
+                .import("polars")?
+                .call_method1("from_pandas", (ob,))?;
             Ok(ArrayData::from(ob.extract::<PyDataFrame>()?.0).into())
         } else if isinstance_of_polars(&ob)? {
             Ok(ArrayData::from(ob.extract::<PyDataFrame>()?.0).into())
         } else {
-            Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                format!("Could not convert Python type {} to Rust data", ob.get_type())
-            ))?
+            Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+                "Could not convert Python type {} to Rust data",
+                ob.get_type()
+            )))?
         }
     }
 }
@@ -83,13 +87,13 @@ impl From<Data> for PyData {
     }
 }
 
-impl Into<Data> for PyData {
-    fn into(self) -> Data {
-        self.0
+impl From<PyData> for Data {
+    fn from(val: PyData) -> Self {
+        val.0
     }
 }
 
-impl<'py> FromPyObject<'_, '_> for PyData {
+impl FromPyObject<'_, '_> for PyData {
     type Error = PyErr;
 
     fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
@@ -117,16 +121,18 @@ fn to_scalar(ob: &Bound<'_, PyAny>) -> PyResult<DynScalar> {
         ob.extract::<f64>().map(Into::into)
     } else {
         Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-            "Could not convert to Scalar"
+            "Could not convert to Scalar",
         ))
     }
 }
 
 fn to_mapping(ob: &Bound<'_, PyAny>) -> PyResult<Mapping> {
     let data: HashMap<String, PyData> = ob.extract()?;
-    let mapping = data.into_iter()
+    let mapping = data
+        .into_iter()
         .map(|(k, v)| (k, v.0))
-        .collect::<HashMap<_, _>>().into();
+        .collect::<HashMap<_, _>>()
+        .into();
     Ok(mapping)
 }
 
@@ -164,8 +170,7 @@ fn scalar_to_py<'py>(s: DynScalar, py: Python<'py>) -> PyResult<Bound<'py, PyAny
 fn mapping_to_python<'py>(d: Mapping, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
     let dict = PyDict::new(py);
     let data: HashMap<String, Data> = d.into();
-    data.into_iter().try_for_each(|(k, v)| {
-        dict.set_item(k, PyData(v).into_pyobject(py)?)
-    })?;
+    data.into_iter()
+        .try_for_each(|(k, v)| dict.set_item(k, PyData(v).into_pyobject(py)?))?;
     Ok(dict.into_any())
 }

--- a/pyanndata/src/data/instance.rs
+++ b/pyanndata/src/data/instance.rs
@@ -1,4 +1,4 @@
-use pyo3::{prelude::*, types::PyType, PyResult};
+use pyo3::{PyResult, prelude::*, types::PyType};
 
 pub fn isinstance_of_csr<'py>(obj: &Bound<'py, PyAny>) -> PyResult<bool> {
     obj.is_instance(
@@ -63,7 +63,7 @@ pub fn isinstance_of_polars<'py>(obj: &Bound<'py, PyAny>) -> PyResult<bool> {
 pub fn is_none_slice<'py>(obj: &Bound<'py, PyAny>) -> PyResult<bool> {
     let py = obj.py();
     Ok(obj.is_none()
-        || obj.is(&py.Ellipsis())
+        || obj.is(py.Ellipsis())
         || (is_slice(obj)
             && obj.eq(py.eval(
                 &std::ffi::CString::new("slice(None, None, None)")?,

--- a/pyanndata/src/data/slice.rs
+++ b/pyanndata/src/data/slice.rs
@@ -1,14 +1,15 @@
 use crate::data::instance::*;
 
+use anndata::data::{SelectInfo, SelectInfoElem, Shape};
 use pyo3::prelude::*;
-use anndata::data::{Shape, SelectInfo, SelectInfoElem};
 
 pub fn to_select_info(ob: &Bound<'_, PyAny>, shape: &Shape) -> PyResult<SelectInfo> {
     let ndim = shape.ndim();
     if is_none_slice(ob)? {
-        Ok(std::iter::repeat(SelectInfoElem::full()).take(ndim).collect())
+        Ok(std::iter::repeat_n(SelectInfoElem::full(), ndim).collect())
     } else if ob.is_instance_of::<pyo3::types::PyTuple>() {
-        ob.try_iter()?.zip(shape.as_ref())
+        ob.try_iter()?
+            .zip(shape.as_ref())
             .map(|(x, len)| to_select_elem(&x?, *len))
             .collect()
     } else {
@@ -47,20 +48,22 @@ pub fn to_select_info(ob: &Bound<'_, PyAny>, shape: &Shape) -> PyResult<SelectIn
 pub fn to_select_elem(ob: &Bound<'_, PyAny>, length: usize) -> PyResult<SelectInfoElem> {
     let select = if let Ok(slice) = ob.cast::<pyo3::types::PySlice>() {
         let s = slice.indices(length.try_into()?)?;
-        ndarray::Slice { 
+        ndarray::Slice {
             start: s.start,
             end: Some(s.stop),
             step: s.step,
-        }.into()
+        }
+        .into()
     } else if is_none_slice(ob)? {
         SelectInfoElem::full()
     } else if ob.is_instance_of::<pyo3::types::PyInt>() {
         ob.extract::<usize>()?.into()
-    } else if isinstance_of_arr(ob)? && ob.getattr("dtype")?.getattr("name")?.extract::<&str>()? == "bool" {
-        let arr = ob
-            .extract::<numpy::PyReadonlyArray1<bool>>()?;
+    } else if isinstance_of_arr(ob)?
+        && ob.getattr("dtype")?.getattr("name")?.extract::<&str>()? == "bool"
+    {
+        let arr = ob.extract::<numpy::PyReadonlyArray1<bool>>()?;
         if arr.len()? == length {
-            boolean_mask_to_indices(arr.as_array().into_iter().map(|x| *x)).into()
+            boolean_mask_to_indices(arr.as_array().into_iter().copied()).into()
         } else {
             panic!("boolean mask dimension mismatched")
         }
@@ -71,13 +74,17 @@ pub fn to_select_elem(ob: &Bound<'_, PyAny>, length: usize) -> PyResult<SelectIn
             Ok(mask) => {
                 if mask.len() == length {
                     boolean_mask_to_indices(mask.into_iter()).into()
-                } else if mask.len() == 0 {
+                } else if mask.is_empty() {
                     Vec::new().into()
                 } else {
                     panic!("boolean mask dimension mismatched")
                 }
             }
-            _ => ob.try_iter()?.map(|x| x.unwrap().extract()).collect::<PyResult<Vec<usize>>>()?.into(),
+            _ => ob
+                .try_iter()?
+                .map(|x| x.unwrap().extract())
+                .collect::<PyResult<Vec<usize>>>()?
+                .into(),
         }
     };
     Ok(select)

--- a/pyanndata/src/lib.rs
+++ b/pyanndata/src/lib.rs
@@ -1,11 +1,10 @@
 pub mod anndata;
-pub mod data;
-pub mod container;
 pub mod config;
+pub mod container;
+pub mod data;
 
-pub use crate::anndata::{AnnData, AnnDataSet, PyAnnData, read, read_mtx, read_dataset, concat};
-pub use crate::container::{
-    PyAxisArrays, PyDataFrameElem, PyElem, PyElemCollection, PyArrayElem,
-    PyChunkedArray,
-};
+pub use crate::anndata::{AnnData, AnnDataSet, PyAnnData, concat, read, read_dataset, read_mtx};
 pub use crate::config::{PyCompression, py_get_default_write_config, py_set_default_write_config};
+pub use crate::container::{
+    PyArrayElem, PyAxisArrays, PyChunkedArray, PyDataFrameElem, PyElem, PyElemCollection,
+};

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -23,3 +23,6 @@ extension-module = ["pyo3/extension-module", "pyanndata/extension-module"]
 [lib]
 name = "anndata_rs"
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true


### PR DESCRIPTION
These are almost all automatic changes, and the changes I did manually were harmless, except for the `into_dyn`→`as_dyn`, for which I added a deprecated alias for backwards compat.