### PR TITLE
ci: release-plz

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,21 @@ jobs:
   test_rust_code:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - &checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        persist-credentials: false
 
-    - uses: actions-rs/toolchain@v1
+    - &install-rust
+      uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: stable
         override: true
 
-    - name: Cache rust build
+    - &cache-rust
+      name: Cache rust build
       uses: Swatinem/rust-cache@v2
 
     - name: Test Rust package
@@ -45,17 +51,9 @@ jobs:
       matrix:
         anndata_version: ['0.9.*', '0.10.*', '0.11.*', '0.12.*']
     steps:
-    - uses: actions/checkout@v6
-
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-
-    - name: Cache rust build
-      uses: Swatinem/rust-cache@v2
-
+    - *checkout
+    - *install-rust
+    - *cache-rust
     - name: Build and test package
       run: |
         pip install --user --upgrade pip
@@ -67,16 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test_python_code]
     steps:
-    - uses: actions/checkout@v6
-
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-
-    - name: Cache rust build
-      uses: Swatinem/rust-cache@v2
+    - *checkout
+    - *install-rust
+    - *cache-rust
 
     - name: Install dependency
       run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,18 @@
+name: PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+jobs:
+  check:
+    name: Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title
+        uses: amannn/action-semantic-pull-request@v6
+        env: # Needs repo options: “Squash and merge” with commit message set to “PR title”
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
 
-
 permissions:
   contents: write  # create and modify the release PR branch
   pull-requests: write  # create and edit the release PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,21 @@
 name: Release-plz
-if: ${{ github.repository_owner == 'scverse' }}
 
 on:
   push:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   # Release unpublished packages.
   release-plz-release:
+    if: ${{ github.repository_owner == 'scverse' }}
     name: Release-plz release
     runs-on: ubuntu-latest
-    permissions: &permissions
-      contents: write  # create and modify the release PR branch
-      pull-requests: write  # create and edit the release PR
+    permissions:
+      contents: write  # delete the release PR branch
+      pull-requests: write  # close the release PR
       id-token: write  # trusted publishing
     steps:
     - &checkout
@@ -34,12 +36,15 @@ jobs:
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
+    if: ${{ github.repository_owner == 'scverse' }}
     name: Release-plz PR
     runs-on: ubuntu-latest
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
-    permissions: *permissions
+    permissions:
+      contents: write  # create/modify the release PR branch
+      pull-requests: write  # create/edit the release PR
     steps:
     - *checkout
     - *install-rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+
+permissions:
+  contents: write  # create and modify the release PR branch
+  pull-requests: write  # create and edit the release PR
+  id-token: write  # trusted publishing
+
+jobs:
+  # Release unpublished packages.
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+    - &checkout
+      name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - &install-rust
+      name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+    - name: Run release-plz
+      uses: release-plz/action@v0.5
+      with:
+        command: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Create a PR with the new versions and changelog, preparing the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+    - *checkout
+    - *install-rust
+    - name: Run release-plz
+      uses: release-plz/action@v0.5
+      with:
+        command: release-pr
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release-plz
+if: ${{ github.repository_owner == 'scverse' }}
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,19 +5,15 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write  # create and modify the release PR branch
-  pull-requests: write  # create and edit the release PR
-  id-token: write  # trusted publishing
-
 jobs:
   # Release unpublished packages.
   release-plz-release:
     name: Release-plz release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: read
+    permissions: &permissions
+      contents: write  # create and modify the release PR branch
+      pull-requests: write  # create and edit the release PR
+      id-token: write  # trusted publishing
     steps:
     - &checkout
       name: Checkout repository
@@ -42,6 +38,7 @@ jobs:
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
+    permissions: *permissions
     steps:
     - *checkout
     - *install-rust

--- a/anndata-hdf5/README.md
+++ b/anndata-hdf5/README.md
@@ -1,0 +1,7 @@
+anndata-hdf5
+============
+
+[HDF5] support for the [anndata] crate.
+
+[HDF5]: https://www.hdfgroup.org/solutions/hdf5/
+[anndata]: https://crates.io/crates/anndata

--- a/anndata-zarr/README.md
+++ b/anndata-zarr/README.md
@@ -1,0 +1,7 @@
+anndata-zarr
+============
+
+[Zarr] support for the [anndata] crate.
+
+[Zarr]: https://zarr.dev/
+[anndata]: https://crates.io/crates/anndata

--- a/pyanndata/README.md
+++ b/pyanndata/README.md
@@ -1,0 +1,7 @@
+pyanndata
+=========
+
+[PyO3] powered Python for the [anndata] crate.
+
+[PyO3]: https://pyo3.rs/
+[anndata]: https://crates.io/crates/anndata

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,5 @@
+# https://release-plz.dev/docs/config
+
+[[package]]
+name = "pyanndata"
+publish = false


### PR DESCRIPTION
https://release-plz.dev/ is the most convenient way to release Rust crates:

1. it maintains a perma-PR that maintains a changelog from conventional commits.
2. when you merge it, it makes releases for all changed crates.
3. the first commit to `main` after merging it opens a new one.